### PR TITLE
Fix Doctrine query error on admin dashboard

### DIFF
--- a/src/Repository/KPIRepository.php
+++ b/src/Repository/KPIRepository.php
@@ -90,9 +90,14 @@ class KPIRepository extends ServiceEntityRepository
      */
     public function countKpisByUser(): array
     {
-        return $this->createQueryBuilder('k')
+        // Use the user entity as root alias to satisfy Doctrine's requirement
+        // of having at least one root entity alias in the SELECT clause when
+        // selecting an entity. This query returns each user with the number of
+        // KPIs assigned to them ordered by the KPI count.
+        return $this->getEntityManager()->createQueryBuilder()
             ->select('u AS user, COUNT(k.id) AS kpi_count')
-            ->join('k.user', 'u')
+            ->from(User::class, 'u')
+            ->leftJoin('u.kpis', 'k')
             ->groupBy('u.id')
             ->orderBy('kpi_count', 'DESC')
             ->getQuery()


### PR DESCRIPTION
## Summary
- fix `countKpisByUser()` query to use User as root alias

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687e98d3a6cc83318744c8fcf8521862