### PR TITLE
Fix missing admin users templates

### DIFF
--- a/templates/admin/users/edit.html.twig
+++ b/templates/admin/users/edit.html.twig
@@ -1,0 +1,42 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Benutzer bearbeiten - KPI Tracker{% endblock %}
+
+{% block page_title %}Benutzer bearbeiten{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_users') }}" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Zurück
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-5">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="bi bi-pencil"></i> Benutzer bearbeiten</h5>
+            </div>
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.email) }}
+                <div class="row">
+                    <div class="col-md-6">{{ form_row(form.firstName) }}</div>
+                    <div class="col-md-6">{{ form_row(form.lastName) }}</div>
+                </div>
+                {{ form_row(form.roles) }}
+                {{ form_row(form.plainPassword) }}
+                <div class="d-flex justify-content-between mt-3">
+                    <a href="{{ path('app_admin_users') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-x-circle"></i> Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-circle"></i> Speichern
+                    </button>
+                </div>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/users/index.html.twig
+++ b/templates/admin/users/index.html.twig
@@ -1,0 +1,92 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Benutzerverwaltung - KPI Tracker{% endblock %}
+
+{% block page_title %}Benutzerverwaltung{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_user_new') }}" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-circle"></i> Neuer Benutzer
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="table-responsive">
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th>E-Mail</th>
+                <th>Name</th>
+                <th>Rolle</th>
+                <th>Erstellt</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for user in users %}
+                <tr>
+                    <td>{{ user.email }}</td>
+                    <td>{{ user.firstName }} {{ user.lastName }}</td>
+                    <td>
+                        {% if user.isAdmin() %}
+                            <span class="badge bg-danger">Admin</span>
+                        {% else %}
+                            <span class="badge bg-secondary">Benutzer</span>
+                        {% endif %}
+                    </td>
+                    <td>{{ user.createdAt|date('d.m.Y') }}</td>
+                    <td class="text-end">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <a href="{{ path('app_admin_user_edit', {id: user.id}) }}" class="btn btn-outline-primary">
+                                <i class="bi bi-pencil"></i>
+                            </a>
+                            <button type="button" class="btn btn-outline-danger" onclick="confirmDelete('{{ user.email }}', '{{ path('app_admin_user_delete', {id: user.id}) }}')">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="5" class="text-center text-muted">Keine Benutzer gefunden.</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<div class="modal fade" id="deleteModal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Benutzer löschen</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                Möchten Sie den Benutzer "<span id="deleteUserEmail"></span>" wirklich löschen?
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Abbrechen</button>
+                <form id="deleteForm" method="post" style="display:inline;">
+                    <input type="hidden" name="_token" value="{{ csrf_token('delete') }}">
+                    <button type="submit" class="btn btn-danger">
+                        <i class="bi bi-trash"></i> Löschen
+                    </button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block javascripts %}
+    {{ parent() }}
+    <script>
+        function confirmDelete(userEmail, deleteUrl) {
+            document.getElementById('deleteUserEmail').textContent = userEmail;
+            document.getElementById('deleteForm').action = deleteUrl;
+            const modal = new bootstrap.Modal(document.getElementById('deleteModal'));
+            modal.show();
+        }
+    </script>
+{% endblock %}

--- a/templates/admin/users/new.html.twig
+++ b/templates/admin/users/new.html.twig
@@ -1,0 +1,42 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Neuen Benutzer anlegen - KPI Tracker{% endblock %}
+
+{% block page_title %}Neuen Benutzer anlegen{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_users') }}" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Zurück
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="row justify-content-center">
+    <div class="col-md-6 col-lg-5">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="bi bi-plus-circle"></i> Benutzer erstellen</h5>
+            </div>
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.email) }}
+                <div class="row">
+                    <div class="col-md-6">{{ form_row(form.firstName) }}</div>
+                    <div class="col-md-6">{{ form_row(form.lastName) }}</div>
+                </div>
+                {{ form_row(form.roles) }}
+                {{ form_row(form.plainPassword) }}
+                <div class="d-flex justify-content-between mt-3">
+                    <a href="{{ path('app_admin_users') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-x-circle"></i> Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-circle"></i> Benutzer erstellen
+                    </button>
+                </div>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin user list template
- add templates for creating and editing users

## Testing
- `composer install`
- `./vendor/bin/phpunit`
- `PHP_CS_FIXER_IGNORE_ENV=1 ./vendor/bin/php-cs-fixer fix --dry-run --diff --allow-risky=yes`


------
https://chatgpt.com/codex/tasks/task_e_687f11e950848331b6658196446974e5