### PR TITLE
Add missing admin KPI templates

### DIFF
--- a/templates/admin/kpis/edit.html.twig
+++ b/templates/admin/kpis/edit.html.twig
@@ -1,0 +1,43 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}KPI bearbeiten - KPI Tracker{% endblock %}
+
+{% block page_title %}KPI bearbeiten{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_kpis') }}" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Zur\xC3\xBCck zu KPIs
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="bi bi-pencil"></i> KPI bearbeiten</h5>
+            </div>
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.user) }}
+                {{ form_row(form.name) }}
+                {{ form_row(form.description) }}
+                <div class="row">
+                    <div class="col-md-6">{{ form_row(form.interval) }}</div>
+                    <div class="col-md-6">{{ form_row(form.unit) }}</div>
+                </div>
+                {{ form_row(form.target) }}
+                <div class="d-flex justify-content-between mt-3">
+                    <a href="{{ path('app_admin_kpis') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-x-circle"></i> Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-circle"></i> Speichern
+                    </button>
+                </div>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/templates/admin/kpis/index.html.twig
+++ b/templates/admin/kpis/index.html.twig
@@ -1,0 +1,57 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Alle KPIs - KPI Tracker{% endblock %}
+
+{% block page_title %}Alle KPIs{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_kpi_new') }}" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-circle"></i> Neue KPI
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="table-responsive">
+    <table class="table table-hover">
+        <thead>
+            <tr>
+                <th>Benutzer</th>
+                <th>KPI</th>
+                <th>Intervall</th>
+                <th>Einheit</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for kpi in kpis %}
+                <tr>
+                    <td>
+                        {{ kpi.user.email }}<br>
+                        <small class="text-muted">{{ kpi.user.firstName }} {{ kpi.user.lastName }}</small>
+                    </td>
+                    <td>{{ kpi.name }}</td>
+                    <td>{{ kpi.interval|trans }}</td>
+                    <td>{{ kpi.unit ?: '-' }}</td>
+                    <td class="text-end">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <a href="{{ path('app_admin_kpi_edit', {id: kpi.id}) }}" class="btn btn-outline-primary" title="Bearbeiten">
+                                <i class="bi bi-pencil"></i>
+                            </a>
+                            <form method="post" action="{{ path('app_admin_kpi_delete', {id: kpi.id}) }}" onsubmit="return confirm('KPI wirklich l\xC3\xB6schen?');" style="display:inline;">
+                                <input type="hidden" name="_token" value="{{ csrf_token('delete' ~ kpi.id) }}">
+                                <button class="btn btn-outline-danger" title="L\xC3\xB6schen">
+                                    <i class="bi bi-trash"></i>
+                                </button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+            {% else %}
+                <tr>
+                    <td colspan="5" class="text-center text-muted">Keine KPIs gefunden.</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/templates/admin/kpis/new.html.twig
+++ b/templates/admin/kpis/new.html.twig
@@ -1,0 +1,43 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}KPI f\xC3\xBCr Benutzer anlegen - KPI Tracker{% endblock %}
+
+{% block page_title %}KPI f\xC3\xBCr Benutzer anlegen{% endblock %}
+
+{% block page_actions %}
+    <a href="{{ path('app_admin_kpis') }}" class="btn btn-outline-secondary btn-sm">
+        <i class="bi bi-arrow-left"></i> Zur\xC3\xBCck zu KPIs
+    </a>
+{% endblock %}
+
+{% block body %}
+<div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+        <div class="card">
+            <div class="card-header">
+                <h5 class="mb-0"><i class="bi bi-plus-circle"></i> KPI erstellen</h5>
+            </div>
+            <div class="card-body">
+                {{ form_start(form) }}
+                {{ form_row(form.user) }}
+                {{ form_row(form.name) }}
+                {{ form_row(form.description) }}
+                <div class="row">
+                    <div class="col-md-6">{{ form_row(form.interval) }}</div>
+                    <div class="col-md-6">{{ form_row(form.unit) }}</div>
+                </div>
+                {{ form_row(form.target) }}
+                <div class="d-flex justify-content-between mt-3">
+                    <a href="{{ path('app_admin_kpis') }}" class="btn btn-outline-secondary">
+                        <i class="bi bi-x-circle"></i> Abbrechen
+                    </a>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-check-circle"></i> KPI erstellen
+                    </button>
+                </div>
+                {{ form_end(form) }}
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add admin KPI templates for listing, creation and editing
- ensure page actions link back to overview

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit -c phpunit.dist.xml --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_687f211d41f48331bfe19327bf648fbe