### PR TITLE
Show latest value on admin KPI list

### DIFF
--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -7,6 +7,7 @@ use App\Entity\User;
 use App\Form\KPIAdminType;
 use App\Form\UserType;
 use App\Repository\KPIRepository;
+use App\Repository\KPIValueRepository;
 use App\Repository\UserRepository;
 use App\Service\UserService;
 use Doctrine\ORM\EntityManagerInterface;
@@ -31,6 +32,7 @@ class AdminController extends AbstractController
         private KPIRepository $kpiRepository,
         private UserService $userService,
         private UserPasswordHasherInterface $passwordHasher,
+        private KPIValueRepository $kpiValueRepository,
     ) {
     }
 
@@ -160,9 +162,15 @@ class AdminController extends AbstractController
     public function kpis(): Response
     {
         $kpis = $this->kpiRepository->findAllWithUser();
+        $lastValues = [];
+
+        foreach ($kpis as $kpi) {
+            $lastValues[$kpi->getId()] = $this->kpiValueRepository->findLatestValueForKpi($kpi);
+        }
 
         return $this->render('admin/kpis/index.html.twig', [
             'kpis' => $kpis,
+            'last_values' => $lastValues,
         ]);
     }
 

--- a/src/Repository/KPIValueRepository.php
+++ b/src/Repository/KPIValueRepository.php
@@ -226,6 +226,20 @@ class KPIValueRepository extends ServiceEntityRepository
     }
 
     /**
+     * Findet den zuletzt erfassten Wert für eine KPI.
+     */
+    public function findLatestValueForKpi(KPI $kpi): ?KPIValue
+    {
+        return $this->createQueryBuilder('v')
+            ->andWhere('v.kpi = :kpi')
+            ->setParameter('kpi', $kpi)
+            ->orderBy('v.period', 'DESC')
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    /**
      * Zählt die Gesamtanzahl aller erfassten Werte.
      */
     public function countAll(): int

--- a/templates/admin/kpis/index.html.twig
+++ b/templates/admin/kpis/index.html.twig
@@ -19,6 +19,7 @@
                 <th>Benutzer</th>
                 <th>Intervall</th>
                 <th>Erstellt</th>
+                <th>Letzter Wert</th>
                 <th></th>
             </tr>
         </thead>
@@ -33,6 +34,15 @@
                         </span>
                     </td>
                     <td>{{ kpi.createdAt|date('d.m.Y') }}</td>
+                    <td>
+                        {% set last_value = last_values[kpi.id] ?? null %}
+                        {% if last_value %}
+                            {{ last_value.value }}{% if kpi.unit %} {{ kpi.unit }}{% endif %}
+                            <br><small class="text-muted">{{ last_value.period }}</small>
+                        {% else %}
+                            <span class="text-muted">-</span>
+                        {% endif %}
+                    </td>
                     <td class="text-end">
                         <div class="btn-group btn-group-sm" role="group">
                             <a href="{{ path('app_admin_kpi_edit', {id: kpi.id}) }}" class="btn btn-outline-primary">
@@ -46,7 +56,7 @@
                 </tr>
             {% else %}
                 <tr>
-                    <td colspan="5" class="text-center text-muted">Keine KPIs gefunden.</td>
+                    <td colspan="6" class="text-center text-muted">Keine KPIs gefunden.</td>
                 </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary
- show most recent KPI value on the admin KPI overview
- add repository helper to fetch latest value
- display that value in the admin KPI table

## Testing
- `composer install --no-interaction --prefer-dist`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687f34dc1e6083319fb84bdc60727e94