### PR TITLE
Sort KPIs by due date on dashboard

### DIFF
--- a/src/Controller/DashboardController.php
+++ b/src/Controller/DashboardController.php
@@ -55,6 +55,15 @@ class DashboardController extends AbstractController
 
         // Nach Fälligkeitsdatum sortieren (nächstes Fälligkeitsdatum zuerst)
         usort($kpiData, static function (array $a, array $b): int {
+            if ($a['next_due_date'] === null && $b['next_due_date'] === null) {
+                return 0;
+            }
+            if ($a['next_due_date'] === null) {
+                return 1;
+            }
+            if ($b['next_due_date'] === null) {
+                return -1;
+            }
             return $a['next_due_date'] <=> $b['next_due_date'];
         });
 


### PR DESCRIPTION
## Summary
- sort KPI data on dashboard by the next due date so the next due KPI appears first

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6880712f7b408331a46dd4831e5c6f80