### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^2.17",
+        "jimdo/prometheus_client_php": "^0.6.0",
         "phpoffice/phpspreadsheet": "^3.0",
         "symfony/asset": "7.3.*",
         "symfony/console": "7.3.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "951f4e39bbef1379ee8e77d2b77490eb",
+    "content-hash": "0756a70181e57e3eb9e5591b600fe09a",
     "packages": [
         {
             "name": "composer/pcre",
@@ -1475,6 +1475,58 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "jimdo/prometheus_client_php",
+            "version": "v0.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jimdo/prometheus_client_php.git",
+                "reference": "43fc3bd312e790fa79457bb5b146ef4132ed9b83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jimdo/prometheus_client_php/zipball/43fc3bd312e790fa79457bb5b146ef4132ed9b83",
+                "reference": "43fc3bd312e790fa79457bb5b146ef4132ed9b83",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.1.0"
+            },
+            "suggest": {
+                "ext-apc": "Required if using APCu.",
+                "ext-redis": "Required if using Redis.",
+                "guzzlehttp/guzzle": "~6.0 for running the blackbox tests."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Prometheus\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joscha",
+                    "email": "joscha@schnipseljagd.org"
+                },
+                {
+                    "name": "Jan Brauer",
+                    "email": "jan.brauer@jimdo.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/Jimdo/prometheus_client_php/issues",
+                "source": "https://github.com/Jimdo/prometheus_client_php/tree/master"
+            },
+            "abandoned": true,
+            "time": "2016-09-07T13:52:03+00:00"
         },
         {
             "name": "maennchen/zipstream-php",

--- a/src/Controller/MetricsController.php
+++ b/src/Controller/MetricsController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Controller;
+
+use App\Repository\KPIValueRepository;
+use Prometheus\CollectorRegistry;
+use Prometheus\RenderTextFormat;
+use Prometheus\Storage\InMemory;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route('/metrics')]
+class MetricsController extends AbstractController
+{
+    #[Route('', name: 'app_metrics', methods: ['GET'])]
+    #[IsGranted('ROLE_ADMIN')]
+    public function metrics(KPIValueRepository $repository): Response
+    {
+        $adapter = new InMemory();
+        $registry = new CollectorRegistry($adapter);
+
+        $gauge = $registry->registerGauge('kpi', 'value', 'KPI historical values', ['kpi_id', 'period', 'kpi_name']);
+
+        $values = $repository->findForAdminExport();
+        foreach ($values as $value) {
+            $kpi = $value->getKpi();
+            $gauge->set((float) $value->getValue(), [
+                (string) $kpi->getId(),
+                $value->getPeriod(),
+                $kpi->getName(),
+            ]);
+        }
+
+        $renderer = new RenderTextFormat();
+        $result = $renderer->render($registry->getMetricFamilySamples());
+
+        return new Response($result, Response::HTTP_OK, ['Content-Type' => RenderTextFormat::MIME_TYPE]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `jimdo/prometheus_client_php` dependency
- expose new `/metrics` endpoint returning all KPI values in Prometheus format

## Testing
- `composer install --no-interaction`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_6880d065e8908331a8c9663ea5687b4d