### PR TITLE
Use DecimalValue value object for KPI numbers

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -22,6 +22,12 @@ doctrine:
                 dir: '%kernel.project_dir%/src/Entity'
                 prefix: 'App\Entity'
                 alias: App
+            Domain:
+                is_bundle: false
+                type: attribute
+                dir: '%kernel.project_dir%/src/Domain'
+                prefix: 'App\Domain'
+                alias: Domain
 
 when@test:
     doctrine:

--- a/migrations/Version20250901160627.php
+++ b/migrations/Version20250901160627.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250901160627 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Refactor DecimalValue implementation: Update KPI target column for embedded DecimalValue objects';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Update KPI target column for DecimalValue embedding with correct nullability
+        $this->addSql('ALTER TABLE kpi ADD target_value NUMERIC(10, 2) DEFAULT NULL, DROP target');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Revert to previous target column structure
+        $this->addSql('ALTER TABLE kpi ADD target NUMERIC(10, 2) DEFAULT NULL, DROP target_value');
+    }
+}

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -31,7 +31,7 @@ class ApiController extends AbstractController
         foreach ($values as $value) {
             $data[] = [
                 'timestamp' => $value->getCreatedAt()->getTimestamp() * 1000,
-                'value' => (float) $value->getValue(),
+                'value' => $value->getValueAsFloat(),
                 'period' => $value->getPeriod()?->value(),
                 'formatted_period' => $value->getFormattedPeriod(),
             ];

--- a/src/Controller/ApiController.php
+++ b/src/Controller/ApiController.php
@@ -32,6 +32,7 @@ class ApiController extends AbstractController
             $data[] = [
                 'timestamp' => $value->getCreatedAt()->getTimestamp() * 1000,
                 'value' => $value->getValueAsFloat(),
+                'value_formatted' => $value->getValue()?->format(),
                 'period' => $value->getPeriod()?->value(),
                 'formatted_period' => $value->getFormattedPeriod(),
             ];
@@ -40,6 +41,8 @@ class ApiController extends AbstractController
         return $this->json([
             'kpi' => $kpi->getName(),
             'unit' => $kpi->getUnit(),
+            'target' => $kpi->getTargetAsFloat(),
+            'target_formatted' => $kpi->getTarget()?->format(),
             'interval' => $kpi->getInterval()?->value,
             'interval_label' => $kpi->getInterval()?->label(),
             'data' => $data,

--- a/src/Controller/MetricsController.php
+++ b/src/Controller/MetricsController.php
@@ -33,7 +33,7 @@ class MetricsController extends AbstractController
         $values = $repository->findForAdminExport();
         foreach ($values as $value) {
             $kpi = $value->getKpi();
-            $gauge->set((float) $value->getValue(), [
+            $gauge->set($value->getValueAsFloat(), [
                 (string) $kpi->getId(),
                 (string) $value->getPeriod(),
                 $kpi->getName(),

--- a/src/Domain/ValueObject/DecimalValue.php
+++ b/src/Domain/ValueObject/DecimalValue.php
@@ -10,19 +10,19 @@ use Doctrine\ORM\Mapping as ORM;
 #[ORM\Embeddable]
 final class DecimalValue
 {
-    private const PATTERN = '/^-?\d+([,.]\d{1,2})?$/';
-
     #[ORM\Column(name: 'value', type: 'decimal', precision: 10, scale: 2)]
     private string $value;
 
     public function __construct(string $value)
     {
-        $normalized = str_replace(',', '.', $value);
-        if (!preg_match(self::PATTERN, $value) || !is_numeric($normalized)) {
+        $normalized = str_replace(',', '.', trim($value));
+        
+        if (!is_numeric($normalized)) {
             throw new \InvalidArgumentException(sprintf('Ungültiger Dezimalwert "%s"', $value));
         }
 
-        $this->value = number_format((float) $normalized, 2, '.', '');
+        $float = (float) $normalized;
+        $this->value = number_format($float, 2, '.', '');
     }
 
     public static function fromString(string $value): self

--- a/src/Domain/ValueObject/DecimalValue.php
+++ b/src/Domain/ValueObject/DecimalValue.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Domain\ValueObject;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Value Object for decimal numbers with validation and formatting.
+ */
+#[ORM\Embeddable]
+final class DecimalValue
+{
+    private const PATTERN = '/^-?\d+([,.]\d{1,2})?$/';
+
+    #[ORM\Column(name: 'value', type: 'decimal', precision: 10, scale: 2)]
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = str_replace(',', '.', $value);
+        if (!preg_match(self::PATTERN, $value) || !is_numeric($normalized)) {
+            throw new \InvalidArgumentException(sprintf('Ungültiger Dezimalwert "%s"', $value));
+        }
+
+        $this->value = number_format((float) $normalized, 2, '.', '');
+    }
+
+    public static function fromString(string $value): self
+    {
+        return new self($value);
+    }
+
+    public function toFloat(): float
+    {
+        return (float) $this->value;
+    }
+
+    public function format(): string
+    {
+        return number_format($this->toFloat(), 2, ',', '');
+    }
+
+    public function __toString(): string
+    {
+        return $this->format();
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Entity/KPI.php
+++ b/src/Entity/KPI.php
@@ -108,13 +108,7 @@ class KPI
     /**
      * Zielwert für den KPI.
      */
-    #[ORM\Embedded(class: DecimalValue::class, columnPrefix: false)]
-    #[ORM\AttributeOverrides([
-        new ORM\AttributeOverride(
-            name: 'value',
-            column: new ORM\Column(name: 'target', type: 'decimal', precision: 10, scale: 2, nullable: true)
-        ),
-    ])]
+    #[ORM\Embedded(class: DecimalValue::class, columnPrefix: 'target_')]
     #[Assert\Valid]
     /**
      * Zielwert für den KPI.

--- a/src/Entity/KPIValue.php
+++ b/src/Entity/KPIValue.php
@@ -28,12 +28,6 @@ class KPIValue
     private ?int $id = null;
 
     #[ORM\Embedded(class: DecimalValue::class, columnPrefix: false)]
-    #[ORM\AttributeOverrides([
-        new ORM\AttributeOverride(
-            name: 'value',
-            column: new ORM\Column(name: 'value', type: 'decimal', precision: 10, scale: 2, nullable: false)
-        ),
-    ])]
     #[Assert\NotNull(message: 'Der Wert ist erforderlich.')]
     #[Assert\Valid]
     /**

--- a/src/Entity/KPIValue.php
+++ b/src/Entity/KPIValue.php
@@ -2,8 +2,9 @@
 
 namespace App\Entity;
 
-use App\Repository\KPIValueRepository;
+use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\Period;
+use App\Repository\KPIValueRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\DBAL\Types\Types;
@@ -26,15 +27,21 @@ class KPIValue
      */
     private ?int $id = null;
 
-    #[ORM\Column(type: Types::DECIMAL, precision: 10, scale: 2)]
-    #[Assert\NotBlank(message: 'Der Wert ist erforderlich.')]
-    #[Assert\Type(type: 'numeric', message: 'Der Wert muss eine Zahl sein.')]
+    #[ORM\Embedded(class: DecimalValue::class, columnPrefix: false)]
+    #[ORM\AttributeOverrides([
+        new ORM\AttributeOverride(
+            name: 'value',
+            column: new ORM\Column(name: 'value', type: 'decimal', precision: 10, scale: 2, nullable: false)
+        ),
+    ])]
+    #[Assert\NotNull(message: 'Der Wert ist erforderlich.')]
+    #[Assert\Valid]
     /**
-     * Erfasster Wert als String (Decimal).
+     * Erfasster Wert.
      *
-     * @var string|null
+     * @var DecimalValue|null
      */
-    private ?string $value = null;
+    private ?DecimalValue $value = null;
 
     /**
      * Zeitraumbezug (z.B. "2024-01", "2024-W05", "2024-Q1").
@@ -117,11 +124,11 @@ class KPIValue
     }
 
     /**
-     * Gibt den erfassten Wert als String zurück.
+     * Gibt den erfassten Wert zurück.
      *
-     * @return string|null
+     * @return DecimalValue|null
      */
-    public function getValue(): ?string
+    public function getValue(): ?DecimalValue
     {
         return $this->value;
     }
@@ -129,11 +136,11 @@ class KPIValue
     /**
      * Setzt den erfassten Wert.
      *
-     * @param string $value
+     * @param DecimalValue $value
      *
      * @return static
      */
-    public function setValue(string $value): static
+    public function setValue(DecimalValue $value): static
     {
         $this->value = $value;
 
@@ -143,14 +150,9 @@ class KPIValue
     /**
      * Gibt den Wert als Float zurück für Berechnungen.
      */
-    /**
-     * Gibt den Wert als Float zurück für Berechnungen.
-     *
-     * @return float
-     */
     public function getValueAsFloat(): float
     {
-        return (float) $this->value;
+        return $this->value->toFloat();
     }
 
     /**
@@ -358,6 +360,6 @@ class KPIValue
      */
     public function __toString(): string
     {
-        return $this->value.' ('.$this->getFormattedPeriod().')';
+        return (string) $this->value.' ('.$this->getFormattedPeriod().')';
     }
 }

--- a/src/Form/KPIAdminType.php
+++ b/src/Form/KPIAdminType.php
@@ -2,6 +2,7 @@
 
 namespace App\Form;
 
+use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\KpiInterval;
 use App\Entity\KPI;
 use App\Entity\User;
@@ -10,6 +11,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -82,9 +84,17 @@ class KPIAdminType extends AbstractType
                 'attr' => [
                     'class' => 'form-control',
                     'placeholder' => 'z.B. 100000, 95, ...',
+                    'pattern' => '[0-9]+([,\\.][0-9]+)?',
+                    'title' => 'Bitte geben Sie eine gültige Zahl ein',
                 ],
                 'help' => 'Angestrebter Zielwert (optional)',
             ]);
+
+        $builder->get('target')
+            ->addModelTransformer(new CallbackTransformer(
+                fn (?DecimalValue $value) => $value?->format() ?? '',
+                fn (?string $value) => $value !== null && $value !== '' ? new DecimalValue($value) : null
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/KPIType.php
+++ b/src/Form/KPIType.php
@@ -2,12 +2,14 @@
 
 namespace App\Form;
 
+use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\KpiInterval;
 use App\Entity\KPI;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -67,9 +69,17 @@ class KPIType extends AbstractType
                 'attr' => [
                     'class' => 'form-control',
                     'placeholder' => 'z.B. 100000, 95, ...',
+                    'pattern' => '[0-9]+([,\\.][0-9]+)?',
+                    'title' => 'Bitte geben Sie eine gültige Zahl ein',
                 ],
                 'help' => 'Angestrebter Zielwert (optional)',
             ]);
+
+        $builder->get('target')
+            ->addModelTransformer(new CallbackTransformer(
+                fn (?DecimalValue $value) => $value?->format() ?? '',
+                fn (?string $value) => $value !== null && $value !== '' ? new DecimalValue($value) : null
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/KPIValueType.php
+++ b/src/Form/KPIValueType.php
@@ -2,13 +2,14 @@
 
 namespace App\Form;
 
+use App\Domain\ValueObject\DecimalValue;
+use App\Domain\ValueObject\Period;
 use App\Entity\KPIValue;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\FileType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\CallbackTransformer;
-use App\Domain\ValueObject\Period;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -61,6 +62,12 @@ class KPIValueType extends AbstractType
                 ],
                 'help' => 'Optional: Dateien als Beleg oder zusätzliche Information anhängen',
             ]);
+
+        $builder->get('value')
+            ->addModelTransformer(new CallbackTransformer(
+                fn (?DecimalValue $value) => $value?->format() ?? '',
+                fn (?string $value) => $value !== null && $value !== '' ? new DecimalValue($value) : null
+            ));
 
         $builder->get('period')
             ->addModelTransformer(new CallbackTransformer(

--- a/src/Repository/KPIValueRepository.php
+++ b/src/Repository/KPIValueRepository.php
@@ -33,7 +33,7 @@ class KPIValueRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.kpi = :kpi')
             ->setParameter('kpi', $kpi)
-            ->orderBy('v.period', 'DESC')
+            ->orderBy('v.period.value', 'DESC')
             ->getQuery()
             ->getResult();
     }
@@ -45,7 +45,7 @@ class KPIValueRepository extends ServiceEntityRepository
     {
         return $this->createQueryBuilder('v')
             ->andWhere('v.kpi = :kpi')
-            ->andWhere('v.period = :period')
+            ->andWhere('v.period.value = :period')
             ->setParameter('kpi', $kpi)
             ->setParameter('period', (string) $period)
             ->getQuery()
@@ -119,7 +119,7 @@ class KPIValueRepository extends ServiceEntityRepository
             ->andWhere('k.user = :user')
             ->setParameter('user', $user)
             ->orderBy('k.name', 'ASC')
-            ->addOrderBy('v.period', 'ASC')
+            ->addOrderBy('v.period.value', 'ASC')
             ->getQuery()
             ->getResult();
     }
@@ -137,7 +137,7 @@ class KPIValueRepository extends ServiceEntityRepository
             ->addSelect('k', 'u')
             ->orderBy('u.email', 'ASC')
             ->addOrderBy('k.name', 'ASC')
-            ->addOrderBy('v.period', 'ASC')
+            ->addOrderBy('v.period.value', 'ASC')
             ->getQuery()
             ->getResult();
     }
@@ -236,7 +236,7 @@ class KPIValueRepository extends ServiceEntityRepository
         return $this->createQueryBuilder('v')
             ->andWhere('v.kpi = :kpi')
             ->setParameter('kpi', $kpi)
-            ->orderBy('v.period', 'DESC')
+            ->orderBy('v.period.value', 'DESC')
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult();

--- a/src/Service/ExcelExportService.php
+++ b/src/Service/ExcelExportService.php
@@ -87,7 +87,7 @@ class ExcelExportService
         return [
             $user?->getEmail() ?? self::DEFAULT_VALUE,
             $kpi?->getName() ?? self::DEFAULT_VALUE,
-            $kpiValue->getValue(),
+            (string) $kpiValue->getValue(),
             (string) $kpiValue->getPeriod(),
             $kpi?->getUnit() ?? self::DEFAULT_VALUE,
         ];

--- a/tests/Domain/ValueObject/DecimalValueTest.php
+++ b/tests/Domain/ValueObject/DecimalValueTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Domain\ValueObject;
+
+use App\Domain\ValueObject\DecimalValue;
+use PHPUnit\Framework\TestCase;
+
+class DecimalValueTest extends TestCase
+{
+    public function testValidDecimalWithComma(): void
+    {
+        $value = new DecimalValue('123,45');
+        $this->assertSame(123.45, $value->toFloat());
+        $this->assertSame('123,45', $value->format());
+    }
+
+    public function testValidDecimalWithDot(): void
+    {
+        $value = new DecimalValue('123.4');
+        $this->assertSame(123.40, $value->toFloat());
+        $this->assertSame('123,40', (string) $value);
+    }
+
+    public function testInvalidDecimalThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new DecimalValue('abc');
+    }
+}

--- a/tests/Domain/ValueObject/DecimalValueTest.php
+++ b/tests/Domain/ValueObject/DecimalValueTest.php
@@ -7,6 +7,9 @@ use PHPUnit\Framework\TestCase;
 
 class DecimalValueTest extends TestCase
 {
+    /**
+     * Testet gültige Dezimalzahlen mit Komma.
+     */
     public function testValidDecimalWithComma(): void
     {
         $value = new DecimalValue('123,45');
@@ -14,16 +17,242 @@ class DecimalValueTest extends TestCase
         $this->assertSame('123,45', $value->format());
     }
 
+    /**
+     * Testet gültige Dezimalzahlen mit Punkt.
+     */
     public function testValidDecimalWithDot(): void
     {
-        $value = new DecimalValue('123.4');
+        $value = new DecimalValue('123.40');
         $this->assertSame(123.40, $value->toFloat());
+        $this->assertSame('123,40', $value->format());
         $this->assertSame('123,40', (string) $value);
     }
 
+    /**
+     * Testet ungültige Dezimalzahlen.
+     */
     public function testInvalidDecimalThrowsException(): void
     {
         $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Ungültiger Dezimalwert "abc"');
         new DecimalValue('abc');
+    }
+
+    /**
+     * Testet negative Zahlen.
+     */
+    public function testNegativeNumbers(): void
+    {
+        $value = new DecimalValue('-456,78');
+        $this->assertSame(-456.78, $value->toFloat());
+        $this->assertSame('-456,78', $value->format());
+        
+        $value2 = new DecimalValue('-100.50');
+        $this->assertSame(-100.50, $value2->toFloat());
+        $this->assertSame('-100,50', $value2->format());
+    }
+
+    /**
+     * Testet Ganzzahlen.
+     */
+    public function testWholeNumbers(): void
+    {
+        $value = new DecimalValue('1000');
+        $this->assertSame(1000.00, $value->toFloat());
+        $this->assertSame('1000,00', $value->format());
+        $this->assertSame('1000.00', $value->getValue());
+    }
+
+    /**
+     * Testet Null-Werte.
+     */
+    public function testZeroValues(): void
+    {
+        $value = new DecimalValue('0');
+        $this->assertSame(0.00, $value->toFloat());
+        $this->assertSame('0,00', $value->format());
+        
+        $value2 = new DecimalValue('0,00');
+        $this->assertSame(0.00, $value2->toFloat());
+        $this->assertSame('0,00', $value2->format());
+    }
+
+    /**
+     * Testet sehr kleine Zahlen.
+     */
+    public function testVerySmallNumbers(): void
+    {
+        $value = new DecimalValue('0,01');
+        $this->assertSame(0.01, $value->toFloat());
+        $this->assertSame('0,01', $value->format());
+    }
+
+    /**
+     * Testet sehr große Zahlen.
+     */
+    public function testVeryLargeNumbers(): void
+    {
+        $value = new DecimalValue('999999,99');
+        $this->assertSame(999999.99, $value->toFloat());
+        $this->assertSame('999999,99', $value->format());
+    }
+
+    /**
+     * Testet Zahlen mit führenden/nachfolgenden Leerzeichen.
+     */
+    public function testTrimming(): void
+    {
+        $value = new DecimalValue('  123,45  ');
+        $this->assertSame(123.45, $value->toFloat());
+        $this->assertSame('123,45', $value->format());
+    }
+
+    /**
+     * Testet Factory-Methode.
+     */
+    public function testFromStringFactory(): void
+    {
+        $value = DecimalValue::fromString('789,12');
+        $this->assertInstanceOf(DecimalValue::class, $value);
+        $this->assertSame(789.12, $value->toFloat());
+    }
+
+    /**
+     * Testet __toString() Methode.
+     */
+    public function testToString(): void
+    {
+        $value = new DecimalValue('250,75');
+        $this->assertSame('250,75', (string) $value);
+    }
+
+    /**
+     * Testet getValue() für Doctrine.
+     */
+    public function testGetValueForDoctrine(): void
+    {
+        $value = new DecimalValue('199,99');
+        $this->assertSame('199.99', $value->getValue());
+    }
+
+    /**
+     * @dataProvider invalidValueProvider
+     */
+    public function testInvalidValues(string $invalidValue): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/Ungültiger Dezimalwert/');
+        new DecimalValue($invalidValue);
+    }
+
+    /**
+     * Provider für ungültige Werte.
+     */
+    public static function invalidValueProvider(): array
+    {
+        return [
+            [''],
+            ['abc'],
+            ['12.34.56'],
+            ['12,34,56'],
+            ['12.3.4'],
+            ['hello123'],
+            ['12a34'],
+            ['..'],
+            [',,'],
+            [' '],
+        ];
+    }
+
+    /**
+     * @dataProvider validValueProvider
+     */
+    public function testValidValues(string $input, float $expectedFloat, string $expectedFormat): void
+    {
+        $value = new DecimalValue($input);
+        $this->assertSame($expectedFloat, $value->toFloat());
+        $this->assertSame($expectedFormat, $value->format());
+    }
+
+    /**
+     * Provider für gültige Werte.
+     */
+    public static function validValueProvider(): array
+    {
+        return [
+            ['123', 123.00, '123,00'],
+            ['123,45', 123.45, '123,45'],
+            ['123.45', 123.45, '123,45'],
+            ['-123,45', -123.45, '-123,45'],
+            ['-123.45', -123.45, '-123,45'],
+            ['0', 0.00, '0,00'],
+            ['0,00', 0.00, '0,00'],
+            ['0.00', 0.00, '0,00'],
+            ['1000000', 1000000.00, '1000000,00'],
+            ['0,01', 0.01, '0,01'],
+            ['999999,99', 999999.99, '999999,99'],
+        ];
+    }
+
+    /**
+     * Testet Präzision (2 Dezimalstellen).
+     */
+    public function testPrecision(): void
+    {
+        $value = new DecimalValue('123,456789');
+        $this->assertSame(123.46, $value->toFloat()); // Rounded to 2 decimals
+        $this->assertSame('123,46', $value->format());
+    }
+
+    /**
+     * Testet Immutability.
+     */
+    public function testImmutability(): void
+    {
+        $value1 = new DecimalValue('100,50');
+        $value2 = DecimalValue::fromString('100,50');
+        
+        $this->assertNotSame($value1, $value2); // Different instances
+        $this->assertSame($value1->getValue(), $value2->getValue()); // Same value
+    }
+
+    /**
+     * Testet JSON-Serialisierung.
+     */
+    public function testJsonSerialization(): void
+    {
+        $value = new DecimalValue('1234,56');
+        
+        // Test direct serialization
+        $data = [
+            'value_float' => $value->toFloat(),
+            'value_formatted' => $value->format(),
+            'value_raw' => $value->getValue(),
+        ];
+        
+        $json = json_encode($data);
+        $decoded = json_decode($json, true);
+        
+        $this->assertSame(1234.56, $decoded['value_float']);
+        $this->assertSame('1234,56', $decoded['value_formatted']);
+        $this->assertSame('1234.56', $decoded['value_raw']);
+    }
+
+    /**
+     * Testet Boundary Values.
+     */
+    public function testBoundaryValues(): void
+    {
+        // Test smallest positive value
+        $small = new DecimalValue('0,01');
+        $this->assertSame(0.01, $small->toFloat());
+        
+        // Test zero
+        $zero = new DecimalValue('0');
+        $this->assertSame(0.00, $zero->toFloat());
+        
+        // Test largest reasonable value (within decimal precision)
+        $large = new DecimalValue('9999999,99');
+        $this->assertSame(9999999.99, $large->toFloat());
     }
 }

--- a/tests/Functional/DecimalValueFunctionalTest.php
+++ b/tests/Functional/DecimalValueFunctionalTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Tests\Functional;
+
+use App\Domain\ValueObject\DecimalValue;
+use App\Domain\ValueObject\KpiInterval;
+use App\Domain\ValueObject\Period;
+use App\Entity\KPI;
+use App\Entity\KPIValue;
+use App\Entity\User;
+use App\Repository\KPIValueRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Functional test to verify DecimalValue implementation works end-to-end.
+ */
+class DecimalValueFunctionalTest extends WebTestCase
+{
+    private EntityManagerInterface $entityManager;
+    private KPIValueRepository $kpiValueRepository;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = static::getContainer()->get('doctrine')->getManager();
+        $this->kpiValueRepository = static::getContainer()->get(KPIValueRepository::class);
+    }
+
+    public function testCompleteDecimalValueWorkflow(): void
+    {
+        // Create test user
+        $user = new User();
+        $user->setEmail('functional-test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Functional');
+        $user->setLastName('Test');
+
+        // Create KPI with DecimalValue target
+        $kpi = new KPI();
+        $kpi->setName('Functional Test KPI');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+        $kpi->setTarget(new DecimalValue('5000,00'));
+
+        // Create KPIValue with DecimalValue
+        $kpiValue = new KPIValue();
+        $kpiValue->setKpi($kpi);
+        $kpiValue->setValue(new DecimalValue('4750,25'));
+        $kpiValue->setPeriod(new Period('2024-09'));
+        $kpiValue->setComment('Functional test value');
+
+        // Persist all entities
+        $this->entityManager->persist($user);
+        $this->entityManager->persist($kpi);
+        $this->entityManager->persist($kpiValue);
+        $this->entityManager->flush();
+
+        // Test repository queries with embedded objects
+        $foundValue = $this->kpiValueRepository->findByKpiAndPeriod($kpi, new Period('2024-09'));
+        $this->assertNotNull($foundValue);
+        $this->assertSame(4750.25, $foundValue->getValueAsFloat());
+        $this->assertSame('4750,25', $foundValue->getValue()->format());
+
+        // Test KPI target functionality
+        $this->assertSame(5000.00, $kpi->getTargetAsFloat());
+        $this->assertSame('5000,00', $kpi->getTarget()->format());
+
+        // Test repository queries
+        $allValues = $this->kpiValueRepository->findByKPI($kpi);
+        $this->assertCount(1, $allValues);
+
+        $latestValue = $this->kpiValueRepository->findLatestValueForKpi($kpi);
+        $this->assertSame($foundValue->getId(), $latestValue->getId());
+
+        // Test string representation
+        $stringRepresentation = (string) $kpiValue;
+        $this->assertStringContainsString('4750,25', $stringRepresentation);
+        $this->assertStringContainsString('September 2024', $stringRepresentation);
+
+        // Cleanup
+        $this->entityManager->remove($kpiValue);
+        $this->entityManager->remove($kpi);
+        $this->entityManager->remove($user);
+        $this->entityManager->flush();
+    }
+
+    public function testRepositoryAverageCalculation(): void
+    {
+        // Create test user and KPI
+        $user = new User();
+        $user->setEmail('avg-test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Average');
+        $user->setLastName('Test');
+
+        $kpi = new KPI();
+        $kpi->setName('Average Test KPI');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+
+        // Create multiple values
+        $value1 = new KPIValue();
+        $value1->setKpi($kpi);
+        $value1->setValue(new DecimalValue('100,00'));
+        $value1->setPeriod(new Period('2024-07'));
+
+        $value2 = new KPIValue();
+        $value2->setKpi($kpi);
+        $value2->setValue(new DecimalValue('200,00'));
+        $value2->setPeriod(new Period('2024-08'));
+
+        $value3 = new KPIValue();
+        $value3->setKpi($kpi);
+        $value3->setValue(new DecimalValue('300,00'));
+        $value3->setPeriod(new Period('2024-09'));
+
+        // Persist entities
+        $this->entityManager->persist($user);
+        $this->entityManager->persist($kpi);
+        $this->entityManager->persist($value1);
+        $this->entityManager->persist($value2);
+        $this->entityManager->persist($value3);
+        $this->entityManager->flush();
+
+        // Test average calculation
+        $average = $this->kpiValueRepository->calculateAverageForKpi($kpi);
+        $this->assertSame(200.0, $average);
+
+        // Test max value finding
+        $maxValue = $this->kpiValueRepository->findMaxValueForKpi($kpi);
+        $this->assertNotNull($maxValue);
+        $this->assertSame(300.0, $maxValue->getValueAsFloat());
+
+        // Cleanup
+        $this->entityManager->remove($value1);
+        $this->entityManager->remove($value2);
+        $this->entityManager->remove($value3);
+        $this->entityManager->remove($kpi);
+        $this->entityManager->remove($user);
+        $this->entityManager->flush();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Close the entity manager to avoid memory leaks
+        $this->entityManager->close();
+        $this->entityManager = null;
+    }
+}

--- a/tests/Functional/DecimalValueFunctionalTest.php
+++ b/tests/Functional/DecimalValueFunctionalTest.php
@@ -145,8 +145,5 @@ class DecimalValueFunctionalTest extends WebTestCase
     {
         parent::tearDown();
 
-        // Close the entity manager to avoid memory leaks
-        $this->entityManager->close();
-        $this->entityManager = null;
     }
 }

--- a/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
+++ b/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
@@ -168,8 +168,4 @@ class DecimalValueIntegrationTest extends KernelTestCase
         $this->assertStringContainsString('September 2024', $stringRepresentation);
     }
 
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
 }

--- a/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
+++ b/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Tests\Integration\ValueObject;
+
+use App\Domain\ValueObject\DecimalValue;
+use App\Domain\ValueObject\KpiInterval;
+use App\Domain\ValueObject\Period;
+use App\Entity\KPI;
+use App\Entity\KPIValue;
+use App\Entity\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Integration Tests for DecimalValue with Entity persistence.
+ */
+class DecimalValueIntegrationTest extends KernelTestCase
+{
+    private EntityManagerInterface $entityManager;
+
+    protected function setUp(): void
+    {
+        $kernel = self::bootKernel();
+        $this->entityManager = $kernel->getContainer()->get('doctrine')->getManager();
+    }
+
+    public function testDecimalValueInKPIEntity(): void
+    {
+        // Create test user
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        // Create KPI with DecimalValue target
+        $kpi = new KPI();
+        $kpi->setName('Test KPI with DecimalValue');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+        $kpi->setTarget(new DecimalValue('1000,50'));
+
+        // Test target functionality
+        $this->assertInstanceOf(DecimalValue::class, $kpi->getTarget());
+        $this->assertSame(1000.50, $kpi->getTargetAsFloat());
+        $this->assertSame('1000,50', $kpi->getTarget()->format());
+
+        // Persist entities (not actually saving to DB in unit test)
+        $this->assertInstanceOf(KPI::class, $kpi);
+    }
+
+    public function testDecimalValueInKPIValueEntity(): void
+    {
+        // Create test user and KPI
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        $kpi = new KPI();
+        $kpi->setName('Test KPI');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+
+        // Create KPIValue with DecimalValue
+        $kpiValue = new KPIValue();
+        $kpiValue->setKpi($kpi);
+        $kpiValue->setValue(new DecimalValue('2500,75'));
+        $kpiValue->setPeriod(new Period('2024-09'));
+
+        // Test value functionality
+        $this->assertInstanceOf(DecimalValue::class, $kpiValue->getValue());
+        $this->assertSame(2500.75, $kpiValue->getValueAsFloat());
+        $this->assertSame('2500,75', $kpiValue->getValue()->format());
+        $this->assertStringContainsString('2500,75', (string) $kpiValue);
+
+        // Test period integration
+        $this->assertSame('September 2024', $kpiValue->getFormattedPeriod());
+    }
+
+    public function testNegativeDecimalValues(): void
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        $kpi = new KPI();
+        $kpi->setName('Test KPI');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+
+        // Test negative value
+        $kpiValue = new KPIValue();
+        $kpiValue->setKpi($kpi);
+        $kpiValue->setValue(new DecimalValue('-150,25'));
+        $kpiValue->setPeriod(new Period('2024-08'));
+
+        $this->assertSame(-150.25, $kpiValue->getValueAsFloat());
+        $this->assertSame('-150,25', $kpiValue->getValue()->format());
+    }
+
+    public function testNullableDecimalValues(): void
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        // KPI without target (nullable)
+        $kpi = new KPI();
+        $kpi->setName('Test KPI without target');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+        // $kpi->setTarget(null); // Explicitly null
+
+        $this->assertNull($kpi->getTarget());
+        $this->assertNull($kpi->getTargetAsFloat());
+    }
+
+    public function testDecimalValueComparisons(): void
+    {
+        $value1 = new DecimalValue('100,50');
+        $value2 = new DecimalValue('100.50');
+        $value3 = new DecimalValue('200,00');
+
+        // Same values in different formats should be equal
+        $this->assertSame($value1->toFloat(), $value2->toFloat());
+        $this->assertSame($value1->getValue(), $value2->getValue());
+
+        // Different values should not be equal
+        $this->assertNotSame($value1->toFloat(), $value3->toFloat());
+    }
+
+    public function testDecimalValuePrecision(): void
+    {
+        // Test precision handling (2 decimal places)
+        $value = new DecimalValue('123,456789');
+        $this->assertSame(123.46, $value->toFloat()); // Rounded to 2 decimals
+        $this->assertSame('123.46', $value->getValue()); // Stored as string
+        $this->assertSame('123,46', $value->format()); // German format
+    }
+
+    public function testEntityStringRepresentation(): void
+    {
+        $user = new User();
+        $user->setEmail('test@example.com');
+        $user->setPassword('password');
+        $user->setFirstName('Test');
+        $user->setLastName('User');
+
+        $kpi = new KPI();
+        $kpi->setName('Revenue KPI');
+        $kpi->setUser($user);
+        $kpi->setInterval(KpiInterval::MONTHLY);
+
+        $kpiValue = new KPIValue();
+        $kpiValue->setKpi($kpi);
+        $kpiValue->setValue(new DecimalValue('5000,00'));
+        $kpiValue->setPeriod(new Period('2024-09'));
+
+        $stringRepresentation = (string) $kpiValue;
+        
+        $this->assertStringContainsString('5000,00', $stringRepresentation);
+        $this->assertStringContainsString('September 2024', $stringRepresentation);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary
- add DecimalValue value object to validate and format decimal strings
- refactor KPI and KPIValue to use DecimalValue with float conversion helpers
- update forms, controllers and services to work with DecimalValue
- cover DecimalValue with unit tests

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b5aa1c3738833196a8ca971d04f6ba