### PR TITLE
Use EmailAddress value object for user emails

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -10,7 +10,7 @@ security:
         app_user_provider:
             entity:
                 class: App\Entity\User
-                property: email
+                property: email.value
 
     firewalls:
         dev:

--- a/migrations/Version20250902071525.php
+++ b/migrations/Version20250902071525.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250902071525 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Change MailSettings username from string to EmailAddress value object';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE kpi CHANGE target_value target_value NUMERIC(10, 2) NOT NULL');
+        $this->addSql('ALTER TABLE mail_settings ADD username_email VARCHAR(180) DEFAULT NULL, DROP username');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_3892618D64C802C8 ON mail_settings (username_email)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX UNIQ_3892618D64C802C8 ON mail_settings');
+        $this->addSql('ALTER TABLE mail_settings ADD username VARCHAR(255) DEFAULT NULL, DROP username_email');
+        $this->addSql('ALTER TABLE kpi CHANGE target_value target_value NUMERIC(10, 2) DEFAULT NULL');
+    }
+}

--- a/src/Command/CreateAdminCommand.php
+++ b/src/Command/CreateAdminCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Entity\User;
+use App\Domain\ValueObject\EmailAddress;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -84,7 +85,7 @@ class CreateAdminCommand extends Command
         }
 
         // Prüfen ob Benutzer bereits existiert
-        $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
+        $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email.value' => $email]);
 
         if ($existingUser && !$force) {
             $io->error("Benutzer mit E-Mail '{$email}' existiert bereits. Verwenden Sie --force zum Überschreiben.");
@@ -116,7 +117,7 @@ class CreateAdminCommand extends Command
                 $io->note("Erstelle neuen Administrator '{$email}'...");
             }
 
-            $user->setEmailWithValidation($email);
+            $user->setEmail(new EmailAddress($email));
             $user->setFirstName($firstName);
             $user->setLastName($lastName);
             $user->setRoles([User::ROLE_ADMIN, User::ROLE_USER]);
@@ -136,7 +137,7 @@ class CreateAdminCommand extends Command
             $io->horizontalTable(
                 ['Eigenschaft', 'Wert'],
                 [
-                    ['E-Mail', $user->getEmail()],
+                    ['E-Mail', $user->getEmail()->getValue()],
                     ['Vorname', $user->getFirstName()],
                     ['Nachname', $user->getLastName()],
                     ['Rollen', implode(', ', $user->getRoles())],

--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Entity\User;
+use App\Domain\ValueObject\EmailAddress;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -98,7 +99,7 @@ class CreateUserCommand extends Command
         }
 
         // Prüfen ob Benutzer bereits existiert
-        $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email' => $email]);
+        $existingUser = $this->entityManager->getRepository(User::class)->findOneBy(['email.value' => $email]);
 
         if ($existingUser && !$force) {
             $io->error("Benutzer mit E-Mail '{$email}' existiert bereits. Verwenden Sie --force zum Überschreiben.");
@@ -117,7 +118,7 @@ class CreateUserCommand extends Command
                 $io->note("Erstelle neuen Benutzer '{$email}'...");
             }
 
-            $user->setEmailWithValidation($email);
+            $user->setEmail(new EmailAddress($email));
             $user->setFirstName($firstName);
             $user->setLastName($lastName);
 
@@ -143,7 +144,7 @@ class CreateUserCommand extends Command
             $io->horizontalTable(
                 ['Eigenschaft', 'Wert'],
                 [
-                    ['E-Mail', $user->getEmail()],
+                    ['E-Mail', $user->getEmail()->getValue()],
                     ['Vorname', $user->getFirstName()],
                     ['Nachname', $user->getLastName()],
                     ['Rollen', implode(', ', $user->getRoles())],

--- a/src/Controller/AdminController.php
+++ b/src/Controller/AdminController.php
@@ -85,7 +85,7 @@ class AdminController extends AbstractController
             $plainPassword = $form->get('plainPassword')->getData();
             $this->adminService->createUser($user, $plainPassword);
 
-            $this->addFlash('success', 'Benutzer "'.$user->getEmail().'" wurde erfolgreich erstellt.');
+            $this->addFlash('success', 'Benutzer "'.$user->getEmail()->getValue().'" wurde erfolgreich erstellt.');
 
             return $this->redirectToRoute('app_admin_users');
         }
@@ -144,7 +144,7 @@ class AdminController extends AbstractController
                 return $this->redirectToRoute('app_admin_users');
             }
 
-            $email = $user->getEmail();
+            $email = $user->getEmail()->getValue();
             $this->userService->deleteUserWithData($user);
 
             $this->addFlash('success', 'Benutzer "'.$email.'" und alle zugehörigen Daten wurden DSGVO-konform gelöscht.');
@@ -201,7 +201,7 @@ class AdminController extends AbstractController
             $this->entityManager->persist($kpi);
             $this->entityManager->flush();
 
-            $this->addFlash('success', 'KPI "'.$kpi->getName().'" wurde für '.$kpi->getUser()->getEmail().' erstellt.');
+            $this->addFlash('success', 'KPI "'.$kpi->getName().'" wurde für '.$kpi->getUser()->getEmail()->getValue().' erstellt.');
 
             return $this->redirectToRoute('app_admin_kpis');
         }
@@ -253,7 +253,7 @@ class AdminController extends AbstractController
     {
         if ($this->isCsrfTokenValid('delete'.$kpi->getId(), $request->request->get('_token'))) {
             $kpiName = $kpi->getName();
-            $userEmail = $kpi->getUser()->getEmail();
+            $userEmail = $kpi->getUser()->getEmail()->getValue();
 
             $this->entityManager->remove($kpi);
             $this->entityManager->flush();

--- a/src/Domain/ValueObject/EmailAddress.php
+++ b/src/Domain/ValueObject/EmailAddress.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Domain\ValueObject;
+
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * Value Object representing a validated and normalized email address.
+ */
+#[ORM\Embeddable]
+final class EmailAddress
+{
+    #[ORM\Column(name: 'email', type: 'string', length: 180, unique: true)]
+    private string $value;
+
+    public function __construct(string $email)
+    {
+        $normalized = mb_strtolower(trim($email));
+        if (!filter_var($normalized, FILTER_VALIDATE_EMAIL)) {
+            throw new \InvalidArgumentException(sprintf('Ungültige E-Mail-Adresse "%s"', $email));
+        }
+
+        $this->value = $normalized;
+    }
+
+    public static function fromString(string $email): self
+    {
+        return new self($email);
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Entity/MailSettings.php
+++ b/src/Entity/MailSettings.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\MailSettingsRepository;
+use App\Domain\ValueObject\EmailAddress;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity(repositoryClass: MailSettingsRepository::class)]
@@ -39,13 +40,13 @@ class MailSettings
      */
     private int $port;
 
-    #[ORM\Column(length: 255, nullable: true)]
+    #[ORM\Embedded(class: EmailAddress::class, columnPrefix: 'username_')]
     /**
-     * Benutzername für die Authentifizierung (optional).
+     * Benutzername für die Authentifizierung (optional) - meist eine E-Mail-Adresse.
      *
-     * @var string|null
+     * @var EmailAddress|null
      */
-    private ?string $username = null;
+    private ?EmailAddress $username = null;
 
     #[ORM\Column(length: 255, nullable: true)]
     /**
@@ -132,9 +133,9 @@ class MailSettings
     /**
      * Gibt den Benutzernamen für die Authentifizierung zurück.
      *
-     * @return string|null
+     * @return EmailAddress|null
      */
-    public function getUsername(): ?string
+    public function getUsername(): ?EmailAddress
     {
         return $this->username;
     }
@@ -142,13 +143,31 @@ class MailSettings
     /**
      * Setzt den Benutzernamen für die Authentifizierung.
      *
+     * @param EmailAddress|null $username
+     *
+     * @return self
+     */
+    public function setUsername(?EmailAddress $username): self
+    {
+        $this->username = $username;
+
+        return $this;
+    }
+
+    /**
+     * Setzt den Benutzernamen aus einem String (mit Validierung).
+     *
      * @param string|null $username
      *
      * @return self
      */
-    public function setUsername(?string $username): self
+    public function setUsernameFromString(?string $username): self
     {
-        $this->username = $username;
+        if ($username === null || trim($username) === '') {
+            $this->username = null;
+        } else {
+            $this->username = new EmailAddress($username);
+        }
 
         return $this;
     }

--- a/src/Form/KPIAdminType.php
+++ b/src/Form/KPIAdminType.php
@@ -29,7 +29,7 @@ class KPIAdminType extends AbstractType
             ->add('user', EntityType::class, [
                 'class' => User::class,
                 'choice_label' => function (User $user) {
-                    return $user->getEmail().' ('.$user->getFirstName().' '.$user->getLastName().')';
+                    return $user->getEmail()->getValue().' ('.$user->getFirstName().' '.$user->getLastName().')';
                 },
                 'label' => 'Benutzer',
                 'attr' => [

--- a/src/Form/MailSettingsType.php
+++ b/src/Form/MailSettingsType.php
@@ -3,7 +3,9 @@
 namespace App\Form;
 
 use App\Entity\MailSettings;
+use App\Domain\ValueObject\EmailAddress;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -37,10 +39,12 @@ class MailSettingsType extends AbstractType
             ])
             ->add('username', TextType::class, [
                 'required' => false,
-                'label' => 'Benutzername',
+                'label' => 'Benutzername (E-Mail)',
                 'attr' => [
                     'class' => 'form-control',
+                    'placeholder' => 'user@smtp-provider.com',
                 ],
+                'help' => 'Meist eine E-Mail-Adresse für SMTP-Authentifizierung',
             ])
             ->add('password', PasswordType::class, [
                 'required' => false,
@@ -64,6 +68,13 @@ class MailSettingsType extends AbstractType
                     'class' => 'form-check-input',
                 ],
             ]);
+
+        // Data Transformer für EmailAddress username
+        $builder->get('username')
+            ->addModelTransformer(new CallbackTransformer(
+                fn (?EmailAddress $email) => $email?->getValue() ?? '',
+                fn (?string $value) => $value !== null && trim($value) !== '' ? new EmailAddress($value) : null
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Form/UserType.php
+++ b/src/Form/UserType.php
@@ -6,6 +6,8 @@ use App\Entity\User;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use App\Domain\ValueObject\EmailAddress;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -123,6 +125,12 @@ class UserType extends AbstractType
                 ],
             ]);
         }
+
+        $builder->get('email')
+            ->addModelTransformer(new CallbackTransformer(
+                fn (?EmailAddress $email) => $email?->getValue() ?? '',
+                fn (?string $value) => $value !== null && $value !== '' ? new EmailAddress($value) : null
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Repository/UserRepository.php
+++ b/src/Repository/UserRepository.php
@@ -45,7 +45,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     public function findByEmail(string $email): ?User
     {
         return $this->createQueryBuilder('u')
-            ->andWhere('u.email = :email')
+            ->andWhere('u.email.value = :email')
             ->setParameter('email', $email)
             ->getQuery()
             ->getOneOrNullResult();
@@ -61,7 +61,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $this->createQueryBuilder('u')
             ->andWhere('u.roles LIKE :role')
             ->setParameter('role', '%'.User::ROLE_ADMIN.'%')
-            ->orderBy('u.email', 'ASC')
+            ->orderBy('u.email.value', 'ASC')
             ->getQuery()
             ->getResult();
     }
@@ -76,7 +76,7 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
         return $this->createQueryBuilder('u')
             ->andWhere('u.roles NOT LIKE :role OR u.roles IS NULL')
             ->setParameter('role', '%'.User::ROLE_ADMIN.'%')
-            ->orderBy('u.email', 'ASC')
+            ->orderBy('u.email.value', 'ASC')
             ->getQuery()
             ->getResult();
     }
@@ -89,9 +89,9 @@ class UserRepository extends ServiceEntityRepository implements PasswordUpgrader
     public function findByEmailLike(string $searchTerm): array
     {
         return $this->createQueryBuilder('u')
-            ->andWhere('u.email LIKE :term')
+            ->andWhere('u.email.value LIKE :term')
             ->setParameter('term', '%'.$searchTerm.'%')
-            ->orderBy('u.email', 'ASC')
+            ->orderBy('u.email.value', 'ASC')
             ->setMaxResults(20)
             ->getQuery()
             ->getResult();

--- a/src/Service/ConfigurableMailer.php
+++ b/src/Service/ConfigurableMailer.php
@@ -40,7 +40,7 @@ class ConfigurableMailer
 
         $dsn = sprintf(
             'smtp://%s:%s@%s:%d',
-            rawurlencode($settings->getUsername() ?? ''),
+            rawurlencode($settings->getUsername()?->getValue() ?? ''),
             rawurlencode($settings->getPassword() ?? ''),
             $settings->getHost(),
             $settings->getPort()

--- a/src/Service/ExcelExportService.php
+++ b/src/Service/ExcelExportService.php
@@ -85,7 +85,7 @@ class ExcelExportService
         $user = $kpi?->getUser();
 
         return [
-            $user?->getEmail() ?? self::DEFAULT_VALUE,
+            $user?->getEmail()?->getValue() ?? self::DEFAULT_VALUE,
             $kpi?->getName() ?? self::DEFAULT_VALUE,
             (string) $kpiValue->getValue(),
             (string) $kpiValue->getPeriod(),

--- a/src/Service/ReminderService.php
+++ b/src/Service/ReminderService.php
@@ -119,7 +119,7 @@ class ReminderService
         try {
             $email = (new Email())
                 ->from($this->fromEmail)
-                ->to($user->getEmail())
+                ->to($user->getEmail()->getValue())
                 ->subject('KPI-Erinnerung: Fällige Einträge in 3 Tagen')
                 ->html($this->twig->render('emails/upcoming_reminder.html.twig', [
                     'user' => $user,
@@ -130,14 +130,14 @@ class ReminderService
             $this->mailer->send($email);
 
             $this->logger->info('Upcoming reminder sent', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'kpi_count' => count($reminders),
             ]);
 
             return true;
         } catch (\Exception $e) {
             $this->logger->error('Failed to send upcoming reminder', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'error' => $e->getMessage(),
             ]);
 
@@ -153,7 +153,7 @@ class ReminderService
         try {
             $email = (new Email())
                 ->from($this->fromEmail)
-                ->to($user->getEmail())
+                ->to($user->getEmail()->getValue())
                 ->subject('KPI-Erinnerung: Einträge sind heute fällig')
                 ->html($this->twig->render('emails/due_today_reminder.html.twig', [
                     'user' => $user,
@@ -164,14 +164,14 @@ class ReminderService
             $this->mailer->send($email);
 
             $this->logger->info('Due today reminder sent', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'kpi_count' => count($reminders),
             ]);
 
             return true;
         } catch (\Exception $e) {
             $this->logger->error('Failed to send due today reminder', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'error' => $e->getMessage(),
             ]);
 
@@ -193,7 +193,7 @@ class ReminderService
 
             $email = (new Email())
                 ->from($this->fromEmail)
-                ->to($user->getEmail())
+                ->to($user->getEmail()->getValue())
                 ->subject("DRINGEND: KPI-Einträge sind seit {$daysOverdue} Tagen überfällig")
                 ->html($this->twig->render('emails/overdue_reminder.html.twig', [
                     'user' => $user,
@@ -206,7 +206,7 @@ class ReminderService
             $this->mailer->send($email);
 
             $this->logger->info('Overdue reminder sent', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'days_overdue' => $daysOverdue,
                 'kpi_count' => count($reminders),
             ]);
@@ -214,7 +214,7 @@ class ReminderService
             return true;
         } catch (\Exception $e) {
             $this->logger->error('Failed to send overdue reminder', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'days_overdue' => $daysOverdue,
                 'error' => $e->getMessage(),
             ]);
@@ -237,7 +237,7 @@ class ReminderService
 
             if (empty($admins)) {
                 $this->logger->warning('No admins found for escalation', [
-                    'user' => $user->getEmail(),
+                    'user' => $user->getEmail()->getValue(),
                 ]);
 
                 return false;
@@ -246,7 +246,7 @@ class ReminderService
             foreach ($admins as $admin) {
                 $email = (new Email())
                     ->from($this->fromEmail)
-                    ->to($admin->getEmail())
+                    ->to($admin->getEmail()->getValue())
                     ->subject('ESKALATION: KPI-Einträge seit 21 Tagen überfällig')
                     ->html($this->twig->render('emails/escalation_to_admin.html.twig', [
                         'admin' => $admin,
@@ -260,7 +260,7 @@ class ReminderService
             }
 
             $this->logger->warning('Escalation sent to admins', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'admin_count' => count($admins),
                 'kpi_count' => count($reminders),
             ]);
@@ -268,7 +268,7 @@ class ReminderService
             return true;
         } catch (\Exception $e) {
             $this->logger->error('Failed to send escalation to admins', [
-                'user' => $user->getEmail(),
+                'user' => $user->getEmail()->getValue(),
                 'error' => $e->getMessage(),
             ]);
 

--- a/src/Service/UserService.php
+++ b/src/Service/UserService.php
@@ -28,7 +28,7 @@ class UserService
      */
     public function deleteUserWithData(User $user): void
     {
-        $userEmail = $user->getEmail();
+        $userEmail = $user->getEmail()->getValue();
         $userId = $user->getId();
 
         $this->logger->info('Starting GDPR-compliant user deletion', [
@@ -121,7 +121,7 @@ class UserService
     public function getUserDeletionStats(User $user): array
     {
         $stats = [
-            'email' => $user->getEmail(),
+            'email' => $user->getEmail()->getValue(),
             'created_at' => $user->getCreatedAt(),
             'kpi_count' => 0,
             'value_count' => 0,

--- a/tests/Domain/ValueObject/EmailAddressTest.php
+++ b/tests/Domain/ValueObject/EmailAddressTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Tests\Domain\ValueObject;
+
+use App\Domain\ValueObject\EmailAddress;
+use PHPUnit\Framework\TestCase;
+
+class EmailAddressTest extends TestCase
+{
+    public function testItNormalizesAndValidates(): void
+    {
+        $email = new EmailAddress(' Test@Example.COM ');
+        $this->assertSame('test@example.com', $email->getValue());
+        $this->assertSame('test@example.com', (string) $email);
+    }
+
+    public function testInvalidEmailThrowsException(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new EmailAddress('invalid-email');
+    }
+}

--- a/tests/Functional/DecimalValueFunctionalTest.php
+++ b/tests/Functional/DecimalValueFunctionalTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Functional;
 use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\KpiInterval;
 use App\Domain\ValueObject\Period;
+use App\Domain\ValueObject\EmailAddress;
 use App\Entity\KPI;
 use App\Entity\KPIValue;
 use App\Entity\User;
@@ -20,7 +21,7 @@ class DecimalValueFunctionalTest extends TestCase
     {
         // Create test user
         $user = new User();
-        $user->setEmail('functional-test@example.com');
+        $user->setEmail(new EmailAddress('functional-test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Functional');
         $user->setLastName('Test');
@@ -85,7 +86,7 @@ class DecimalValueFunctionalTest extends TestCase
     {
         // Create complete entity structure
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');

--- a/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
+++ b/tests/Integration/ValueObject/DecimalValueIntegrationTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Integration\ValueObject;
 use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\KpiInterval;
 use App\Domain\ValueObject\Period;
+use App\Domain\ValueObject\EmailAddress;
 use App\Entity\KPI;
 use App\Entity\KPIValue;
 use App\Entity\User;
@@ -28,7 +29,7 @@ class DecimalValueIntegrationTest extends KernelTestCase
     {
         // Create test user
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -53,7 +54,7 @@ class DecimalValueIntegrationTest extends KernelTestCase
     {
         // Create test user and KPI
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -82,7 +83,7 @@ class DecimalValueIntegrationTest extends KernelTestCase
     public function testNegativeDecimalValues(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -105,7 +106,7 @@ class DecimalValueIntegrationTest extends KernelTestCase
     public function testNullableDecimalValues(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -147,7 +148,7 @@ class DecimalValueIntegrationTest extends KernelTestCase
     public function testEntityStringRepresentation(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');

--- a/tests/Integration/ValueObject/KpiIntervalIntegrationTest.php
+++ b/tests/Integration/ValueObject/KpiIntervalIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace App\Tests\Integration\ValueObject;
 
 use App\Domain\ValueObject\KpiInterval;
+use App\Domain\ValueObject\EmailAddress;
 use App\Entity\KPI;
 use App\Entity\User;
 use Doctrine\ORM\EntityManagerInterface;
@@ -29,7 +30,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testKpiIntervalInEntity(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -50,7 +51,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testAllIntervalTypesInEntity(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -78,7 +79,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testGetCurrentPeriodWithDifferentIntervals(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -117,7 +118,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testGetNextDueDateWithDifferentIntervals(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -147,7 +148,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testJsonSerialization(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -177,7 +178,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testIntervalConsistency(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
@@ -214,7 +215,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
     public function testPeriodCalculationEdgeCases(): void
     {
         $user = new User();
-        $user->setEmail('test@example.com');
+        $user->setEmail(new EmailAddress('test@example.com'));
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');

--- a/tests/Service/ReminderServiceTest.php
+++ b/tests/Service/ReminderServiceTest.php
@@ -6,6 +6,7 @@ use App\Repository\KPIRepository;
 use App\Service\ConfigurableMailer;
 use App\Service\KPIStatusService;
 use App\Service\ReminderService;
+use App\Domain\ValueObject\EmailAddress;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
@@ -62,7 +63,7 @@ class ReminderServiceTest extends TestCase
         $user = $this->createMock(\App\Entity\User::class);
 
         $kpi->method('getUser')->willReturn($user);
-        $user->method('getEmail')->willReturn('user@example.com');
+        $user->method('getEmail')->willReturn(new EmailAddress('user@example.com'));
         $kpiRepo->method('findDueForReminder')->willReturn([$kpi]);
 
         $service = new ReminderService($mailer, $twig, $urlGen, $statusService, $kpiRepo, $logger, 'noreply@kpi-tracker.local');

--- a/tests/Service/UserServiceTest.php
+++ b/tests/Service/UserServiceTest.php
@@ -4,6 +4,7 @@ namespace App\Tests\Service;
 
 use App\Entity\User;
 use App\Service\UserService;
+use App\Domain\ValueObject\EmailAddress;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -15,7 +16,7 @@ class UserServiceTest extends TestCase
         $em = $this->createMock(EntityManagerInterface::class);
         $logger = $this->createMock(LoggerInterface::class);
         $user = $this->createMock(User::class);
-        $user->method('getEmail')->willReturn('test@example.com');
+        $user->method('getEmail')->willReturn(new EmailAddress('test@example.com'));
         $user->method('getId')->willReturn(1);
         $calls = [];
         $logger->method('info')->willReturnCallback(function ($msg, $context) use (&$calls) {
@@ -44,7 +45,7 @@ class UserServiceTest extends TestCase
         $user = $this->createMock(User::class);
 
         $user->method('getKpis')->willReturn(new \Doctrine\Common\Collections\ArrayCollection([]));
-        $user->method('getEmail')->willReturn('test@example.com');
+        $user->method('getEmail')->willReturn(new EmailAddress('test@example.com'));
         $user->method('getCreatedAt')->willReturn(new \DateTimeImmutable());
 
         $service = new UserService($em, $logger);


### PR DESCRIPTION
## Summary
- Add `EmailAddress` value object with validation and normalization
- Replace primitive email fields with `EmailAddress` in `User` entity and related services/forms
- Adjust security configuration, repository queries and tests

## Testing
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_68b5cb0d33288331b56e0d2df136616f