### PR TITLE
refactor reminder emails with factory

### DIFF
--- a/src/Factory/ReminderEmailFactory.php
+++ b/src/Factory/ReminderEmailFactory.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\User;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+/**
+ * Factory zum Erstellen von E-Mails für KPI-Erinnerungen.
+ */
+class ReminderEmailFactory
+{
+    /**
+     * @param Environment           $twig         Twig-Umgebung zum Rendern der HTML-Vorlagen
+     * @param UrlGeneratorInterface $urlGenerator Generiert absolute URLs für Links in den E-Mails
+     * @param string                $fromEmail    Standard-Absenderadresse
+     */
+    public function __construct(
+        private Environment $twig,
+        private UrlGeneratorInterface $urlGenerator,
+        private string $fromEmail = 'noreply@kpi-tracker.local',
+    ) {
+    }
+
+    /**
+     * Erstellt eine Erinnerung für bevorstehende KPI-Einträge (in 3 Tagen fällig).
+     *
+     * @param User  $user      Empfänger der E-Mail
+     * @param array $reminders Liste der fälligen KPIs
+     *
+     * @return Email
+     */
+    public function createUpcoming(User $user, array $reminders): Email
+    {
+        return (new Email())
+            ->from($this->fromEmail)
+            ->to($user->getEmail())
+            ->subject('KPI-Erinnerung: Fällige Einträge in 3 Tagen')
+            ->html($this->twig->render('emails/upcoming_reminder.html.twig', [
+                'user' => $user,
+                'reminders' => $reminders,
+                'dashboard_url' => $this->urlGenerator->generate('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]));
+    }
+
+    /**
+     * Erstellt eine Erinnerung für KPI-Einträge, die heute fällig sind.
+     *
+     * @param User  $user      Empfänger der E-Mail
+     * @param array $reminders Liste der fälligen KPIs
+     *
+     * @return Email
+     */
+    public function createDueToday(User $user, array $reminders): Email
+    {
+        return (new Email())
+            ->from($this->fromEmail)
+            ->to($user->getEmail())
+            ->subject('KPI-Erinnerung: Einträge sind heute fällig')
+            ->html($this->twig->render('emails/due_today_reminder.html.twig', [
+                'user' => $user,
+                'reminders' => $reminders,
+                'dashboard_url' => $this->urlGenerator->generate('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]));
+    }
+
+    /**
+     * Erstellt eine Erinnerung für überfällige KPI-Einträge.
+     *
+     * @param User  $user        Empfänger der E-Mail
+     * @param array $reminders   Liste der überfälligen KPIs
+     * @param int   $daysOverdue Anzahl der Tage, die die KPIs überfällig sind
+     *
+     * @return Email
+     */
+    public function createOverdue(User $user, array $reminders, int $daysOverdue): Email
+    {
+        $urgencyLevel = match ($daysOverdue) {
+            7 => 'medium',
+            14 => 'high',
+            default => 'low',
+        };
+
+        return (new Email())
+            ->from($this->fromEmail)
+            ->to($user->getEmail())
+            ->subject("DRINGEND: KPI-Einträge sind seit {$daysOverdue} Tagen überfällig")
+            ->html($this->twig->render('emails/overdue_reminder.html.twig', [
+                'user' => $user,
+                'reminders' => $reminders,
+                'days_overdue' => $daysOverdue,
+                'urgency_level' => $urgencyLevel,
+                'dashboard_url' => $this->urlGenerator->generate('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]));
+    }
+
+    /**
+     * Erstellt eine Eskalations-E-Mail an den Administrator, wenn KPIs überfällig sind.
+     *
+     * @param User  $admin       Administrator, der die E-Mail erhält
+     * @param User  $user        Benutzer, dessen KPIs überfällig sind
+     * @param array $reminders   Liste der überfälligen KPIs
+     * @param int   $daysOverdue Anzahl der überfälligen Tage (Standard 21)
+     *
+     * @return Email
+     */
+    public function createEscalation(User $admin, User $user, array $reminders, int $daysOverdue = 21): Email
+    {
+        return (new Email())
+            ->from($this->fromEmail)
+            ->to($admin->getEmail())
+            ->subject('ESKALATION: KPI-Einträge seit 21 Tagen überfällig')
+            ->html($this->twig->render('emails/escalation_to_admin.html.twig', [
+                'admin' => $admin,
+                'user' => $user,
+                'reminders' => $reminders,
+                'days_overdue' => $daysOverdue,
+                'admin_url' => $this->urlGenerator->generate('app_admin_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL),
+            ]));
+    }
+
+    /**
+     * Erstellt eine Test-E-Mail, um die Konfiguration zu prüfen.
+     *
+     * @param string $recipientEmail Empfänger der Test-E-Mail
+     *
+     * @return Email
+     */
+    public function createTest(string $recipientEmail): Email
+    {
+        return (new Email())
+            ->from($this->fromEmail)
+            ->to($recipientEmail)
+            ->subject('KPI-Tracker: Test-E-Mail')
+            ->html($this->twig->render('emails/test_email.html.twig', [
+                'recipient' => $recipientEmail,
+                'timestamp' => new \DateTimeImmutable(),
+            ]));
+    }
+}

--- a/tests/Factory/ReminderEmailFactoryTest.php
+++ b/tests/Factory/ReminderEmailFactoryTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace App\Tests\Factory;
+
+use App\Entity\User;
+use App\Factory\ReminderEmailFactory;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\Environment;
+
+/**
+ * Unit-Tests für {@see ReminderEmailFactory}.
+ */
+class ReminderEmailFactoryTest extends TestCase
+{
+    /** @var Environment&MockObject */
+    private Environment $twig;
+
+    /** @var UrlGeneratorInterface&MockObject */
+    private UrlGeneratorInterface $urlGenerator;
+
+    private ReminderEmailFactory $factory;
+
+    protected function setUp(): void
+    {
+        $this->twig = $this->createMock(Environment::class);
+        $this->urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+
+        $this->factory = new ReminderEmailFactory(
+            $this->twig,
+            $this->urlGenerator,
+            'from@example.com'
+        );
+    }
+
+    #[Test]
+    public function createUpcomingRendersTemplateAndBuildsEmail(): void
+    {
+        $user = (new User())->setEmail('user@example.com');
+        $reminders = ['foo'];
+
+        $this->urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://dashboard');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'emails/upcoming_reminder.html.twig',
+                $this->callback(fn (array $context) => $context['user'] === $user
+                    && $context['reminders'] === $reminders
+                    && 'http://dashboard' === $context['dashboard_url'])
+            )
+            ->willReturn('<html>upcoming</html>');
+
+        $email = $this->factory->createUpcoming($user, $reminders);
+
+        $this->assertInstanceOf(Email::class, $email);
+        $this->assertSame('from@example.com', $email->getFrom()[0]->getAddress());
+        $this->assertSame('user@example.com', $email->getTo()[0]->getAddress());
+        $this->assertSame('KPI-Erinnerung: Fällige Einträge in 3 Tagen', $email->getSubject());
+        $this->assertSame('<html>upcoming</html>', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function createDueTodayRendersTemplateAndBuildsEmail(): void
+    {
+        $user = (new User())->setEmail('user@example.com');
+        $reminders = ['bar'];
+
+        $this->urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://dashboard');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'emails/due_today_reminder.html.twig',
+                $this->callback(fn (array $context) => $context['user'] === $user
+                    && $context['reminders'] === $reminders
+                    && 'http://dashboard' === $context['dashboard_url'])
+            )
+            ->willReturn('<html>today</html>');
+
+        $email = $this->factory->createDueToday($user, $reminders);
+
+        $this->assertSame('KPI-Erinnerung: Einträge sind heute fällig', $email->getSubject());
+        $this->assertSame('<html>today</html>', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function createOverdueIncludesUrgencyAndDays(): void
+    {
+        $user = (new User())->setEmail('user@example.com');
+        $reminders = ['baz'];
+
+        $this->urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('app_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://dashboard');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'emails/overdue_reminder.html.twig',
+                $this->callback(fn (array $context) => $context['user'] === $user
+                    && $context['reminders'] === $reminders
+                    && 14 === $context['days_overdue']
+                    && 'high' === $context['urgency_level']
+                    && 'http://dashboard' === $context['dashboard_url'])
+            )
+            ->willReturn('<html>overdue</html>');
+
+        $email = $this->factory->createOverdue($user, $reminders, 14);
+
+        $this->assertSame('DRINGEND: KPI-Einträge sind seit 14 Tagen überfällig', $email->getSubject());
+        $this->assertSame('<html>overdue</html>', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function createEscalationSendsToAdmin(): void
+    {
+        $admin = (new User())->setEmail('admin@example.com');
+        $user = (new User())->setEmail('user@example.com');
+        $reminders = ['abc'];
+
+        $this->urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with('app_admin_dashboard', [], UrlGeneratorInterface::ABSOLUTE_URL)
+            ->willReturn('http://admin');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'emails/escalation_to_admin.html.twig',
+                $this->callback(fn (array $context) => $context['admin'] === $admin
+                    && $context['user'] === $user
+                    && $context['reminders'] === $reminders
+                    && 21 === $context['days_overdue']
+                    && 'http://admin' === $context['admin_url'])
+            )
+            ->willReturn('<html>escalation</html>');
+
+        $email = $this->factory->createEscalation($admin, $user, $reminders);
+
+        $this->assertSame('admin@example.com', $email->getTo()[0]->getAddress());
+        $this->assertSame('ESKALATION: KPI-Einträge seit 21 Tagen überfällig', $email->getSubject());
+        $this->assertSame('<html>escalation</html>', $email->getHtmlBody());
+    }
+
+    #[Test]
+    public function createTestEmail(): void
+    {
+        $this->urlGenerator->expects($this->never())->method('generate');
+
+        $this->twig->expects($this->once())
+            ->method('render')
+            ->with(
+                'emails/test_email.html.twig',
+                $this->callback(fn (array $context) => 'test@example.com' === $context['recipient']
+                    && $context['timestamp'] instanceof \DateTimeImmutable)
+            )
+            ->willReturn('<html>test</html>');
+
+        $email = $this->factory->createTest('test@example.com');
+
+        $this->assertSame('test@example.com', $email->getTo()[0]->getAddress());
+        $this->assertSame('KPI-Tracker: Test-E-Mail', $email->getSubject());
+        $this->assertSame('<html>test</html>', $email->getHtmlBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPDoc comments to `ReminderEmailFactory` for clarity
- cover `ReminderEmailFactory` with unit tests

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/php-cs-fixer fix src/Factory/ReminderEmailFactory.php tests/Factory/ReminderEmailFactoryTest.php --diff --allow-risky=yes --config=.php-cs-fixer.dist.php`


------
https://chatgpt.com/codex/tasks/task_e_68b69f35fc608331950592f4f7f3b7f9