### PR TITLE
Use factories for KPI entities

### DIFF
--- a/src/Controller/KPIController.php
+++ b/src/Controller/KPIController.php
@@ -214,8 +214,7 @@ class KPIController extends AbstractController
 
         $kpiValue = $this->kpiValueFactory->create($kpi);
 
-        // Aktuellen Zeitraum als Standardwert vorschlagen
-        $currentPeriod = $kpiValue->getPeriod();
+    // Aktuellen Zeitraum wird bereits im Factory gesetzt
 
         $form = $this->createForm(KPIValueType::class, $kpiValue);
         $form->handleRequest($request);

--- a/src/Factory/KPIFactory.php
+++ b/src/Factory/KPIFactory.php
@@ -6,13 +6,23 @@ use App\Entity\KPI;
 use App\Entity\User;
 use App\Domain\ValueObject\KpiInterval;
 
+
+/**
+ * Factory für die Erstellung von KPI-Entitäten.
+ */
 class KPIFactory
 {
+    /**
+     * Erstellt eine neue KPI-Entität für einen Benutzer mit Standard-Intervall.
+     *
+     * @param User $user Der Benutzer, dem die KPI zugeordnet wird
+     * @return KPI Die neu erstellte KPI-Entität
+     */
     public function createForUser(User $user): KPI
     {
         $kpi = new KPI();
         $kpi->setUser($user);
-        // Set default interval if needed
+        // Setzt das Standardintervall auf monatlich
         $kpi->setInterval(KpiInterval::MONTHLY);
 
         return $kpi;

--- a/src/Factory/KPIFactory.php
+++ b/src/Factory/KPIFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\KPI;
+use App\Entity\User;
+use App\Domain\ValueObject\KpiInterval;
+
+class KPIFactory
+{
+    public function createForUser(User $user): KPI
+    {
+        $kpi = new KPI();
+        $kpi->setUser($user);
+        // Set default interval if needed
+        $kpi->setInterval(KpiInterval::MONTHLY);
+
+        return $kpi;
+    }
+}

--- a/src/Factory/KPIValueFactory.php
+++ b/src/Factory/KPIValueFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Factory;
+
+use App\Entity\KPI;
+use App\Entity\KPIValue;
+use App\Domain\ValueObject\Period;
+
+class KPIValueFactory
+{
+    public function create(KPI $kpi, ?Period $period = null): KPIValue
+    {
+        $kpiValue = new KPIValue();
+        $kpiValue->setKpi($kpi);
+        $kpiValue->setPeriod($period ?? $kpi->getCurrentPeriod());
+        $kpiValue->setCreatedAt(new \DateTimeImmutable());
+        $kpiValue->setUpdatedAt(null);
+
+        return $kpiValue;
+    }
+}

--- a/src/Factory/KPIValueFactory.php
+++ b/src/Factory/KPIValueFactory.php
@@ -6,8 +6,19 @@ use App\Entity\KPI;
 use App\Entity\KPIValue;
 use App\Domain\ValueObject\Period;
 
+
+/**
+ * Factory zur Erstellung von KPIValue-Entitäten.
+ */
 class KPIValueFactory
 {
+    /**
+     * Erstellt eine neue KPIValue-Entität für ein KPI und einen Zeitraum.
+     *
+     * @param KPI $kpi Das zugehörige KPI-Objekt
+     * @param Period|null $period Der Zeitraum, optional. Falls nicht gesetzt, wird das aktuelle Period des KPI verwendet
+     * @return KPIValue Die neu erstellte KPIValue-Entität
+     */
     public function create(KPI $kpi, ?Period $period = null): KPIValue
     {
         $kpiValue = new KPIValue();

--- a/tests/Factory/KPIValueFactoryTest.php
+++ b/tests/Factory/KPIValueFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Tests\Factory;
+
+use App\Entity\KPI;
+use App\Entity\KPIValue;
+use App\Domain\ValueObject\Period;
+use App\Factory\KPIValueFactory;
+use PHPUnit\Framework\TestCase;
+
+class KPIValueFactoryTest extends TestCase
+{
+    public function testCreateWithExplicitPeriod(): void
+    {
+        $kpi = $this->createMock(KPI::class);
+        $period = new Period('2025-09');
+        $factory = new KPIValueFactory();
+
+        $kpiValue = $factory->create($kpi, $period);
+
+        $this->assertInstanceOf(KPIValue::class, $kpiValue);
+        $this->assertSame($kpi, $kpiValue->getKpi());
+        $this->assertSame($period, $kpiValue->getPeriod());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $kpiValue->getCreatedAt());
+        $this->assertNull($kpiValue->getUpdatedAt());
+    }
+
+    public function testCreateWithDefaultPeriod(): void
+    {
+        $period = new Period('2025-09');
+        $kpi = $this->createMock(KPI::class);
+        $kpi->method('getCurrentPeriod')->willReturn($period);
+        $factory = new KPIValueFactory();
+
+        $kpiValue = $factory->create($kpi);
+
+        $this->assertInstanceOf(KPIValue::class, $kpiValue);
+        $this->assertSame($kpi, $kpiValue->getKpi());
+        $this->assertSame($period, $kpiValue->getPeriod());
+        $this->assertInstanceOf(\DateTimeImmutable::class, $kpiValue->getCreatedAt());
+        $this->assertNull($kpiValue->getUpdatedAt());
+    }
+}

--- a/tests/Functional/DecimalValueFunctionalTest.php
+++ b/tests/Functional/DecimalValueFunctionalTest.php
@@ -6,9 +6,9 @@ use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\KpiInterval;
 use App\Domain\ValueObject\Period;
 use App\Domain\ValueObject\EmailAddress;
-use App\Entity\KPI;
-use App\Entity\KPIValue;
 use App\Entity\User;
+use App\Factory\KPIFactory;
+use App\Factory\KPIValueFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,18 +26,18 @@ class DecimalValueFunctionalTest extends TestCase
         $user->setFirstName('Functional');
         $user->setLastName('Test');
 
+        $kpiFactory = new KPIFactory();
+        $kpiValueFactory = new KPIValueFactory();
+
         // Create KPI with DecimalValue target
-        $kpi = new KPI();
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Functional Test KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::MONTHLY);
         $kpi->setTarget(new DecimalValue('5000,00'));
 
         // Create KPIValue with DecimalValue
-        $kpiValue = new KPIValue();
-        $kpiValue->setKpi($kpi);
+        $kpiValue = $kpiValueFactory->create($kpi, new Period('2024-09'));
         $kpiValue->setValue(new DecimalValue('4750,25'));
-        $kpiValue->setPeriod(new Period('2024-09'));
         $kpiValue->setComment('Functional test value');
 
         // Test value functionality (without database persistence)
@@ -91,16 +91,16 @@ class DecimalValueFunctionalTest extends TestCase
         $user->setFirstName('Test');
         $user->setLastName('User');
 
-        $kpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpiValueFactory = new KPIValueFactory();
+
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Test KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::WEEKLY);
         $kpi->setTarget(new DecimalValue('2500,50'));
 
-        $kpiValue = new KPIValue();
-        $kpiValue->setKpi($kpi);
+        $kpiValue = $kpiValueFactory->create($kpi, new Period('2024-W36'));
         $kpiValue->setValue(new DecimalValue('2300,25'));
-        $kpiValue->setPeriod(new Period('2024-W36'));
 
         // Test bidirectional relationships
         $this->assertSame($kpi, $kpiValue->getKpi());

--- a/tests/Integration/ValueObject/KpiIntervalIntegrationTest.php
+++ b/tests/Integration/ValueObject/KpiIntervalIntegrationTest.php
@@ -4,8 +4,8 @@ namespace App\Tests\Integration\ValueObject;
 
 use App\Domain\ValueObject\KpiInterval;
 use App\Domain\ValueObject\EmailAddress;
-use App\Entity\KPI;
 use App\Entity\User;
+use App\Factory\KPIFactory;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -34,10 +34,9 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
-
-        $kpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Test KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::WEEKLY);
 
         $this->assertSame(KpiInterval::WEEKLY, $kpi->getInterval());
@@ -56,6 +55,8 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setFirstName('Test');
         $user->setLastName('User');
 
+        $kpiFactory = new KPIFactory();
+
         $intervals = [
             KpiInterval::WEEKLY,
             KpiInterval::MONTHLY,
@@ -63,9 +64,8 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         ];
 
         foreach ($intervals as $interval) {
-            $kpi = new KPI();
+            $kpi = $kpiFactory->createForUser($user);
             $kpi->setName('Test KPI '.$interval->value);
-            $kpi->setUser($user);
             $kpi->setInterval($interval);
 
             $this->assertSame($interval, $kpi->getInterval());
@@ -83,29 +83,27 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
+        $kpiFactory = new KPIFactory();
 
         // Weekly KPI
-        $weeklyKpi = new KPI();
+        $weeklyKpi = $kpiFactory->createForUser($user);
         $weeklyKpi->setName('Weekly KPI');
-        $weeklyKpi->setUser($user);
         $weeklyKpi->setInterval(KpiInterval::WEEKLY);
 
         $weeklyPeriod = $weeklyKpi->getCurrentPeriod();
         $this->assertMatchesRegularExpression('/^\d{4}-W\d{2}$/', (string) $weeklyPeriod); // Format: YYYY-WXX
 
         // Monthly KPI
-        $monthlyKpi = new KPI();
+        $monthlyKpi = $kpiFactory->createForUser($user);
         $monthlyKpi->setName('Monthly KPI');
-        $monthlyKpi->setUser($user);
         $monthlyKpi->setInterval(KpiInterval::MONTHLY);
 
         $monthlyPeriod = $monthlyKpi->getCurrentPeriod();
         $this->assertMatchesRegularExpression('/^\d{4}-\d{2}$/', $monthlyPeriod);
 
         // Quarterly KPI
-        $quarterlyKpi = new KPI();
+        $quarterlyKpi = $kpiFactory->createForUser($user);
         $quarterlyKpi->setName('Quarterly KPI');
-        $quarterlyKpi->setUser($user);
         $quarterlyKpi->setInterval(KpiInterval::QUARTERLY);
 
         $quarterlyPeriod = $quarterlyKpi->getCurrentPeriod();
@@ -122,6 +120,7 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
+        $kpiFactory = new KPIFactory();
 
         $intervals = [
             KpiInterval::WEEKLY,
@@ -130,9 +129,8 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         ];
 
         foreach ($intervals as $interval) {
-            $kpi = new KPI();
+            $kpi = $kpiFactory->createForUser($user);
             $kpi->setName('Test KPI '.$interval->value);
-            $kpi->setUser($user);
             $kpi->setInterval($interval);
 
             $dueDate = $kpi->getNextDueDate();
@@ -152,10 +150,9 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
-
-        $kpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Test KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::MONTHLY);
 
         $data = [
@@ -182,27 +179,25 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
+        $kpiFactory = new KPIFactory();
 
         // Teste, dass weekly tatsächlich wöchentliche Formate erzeugt (Format: YYYY-WXX)
-        $weeklyKpi = new KPI();
+        $weeklyKpi = $kpiFactory->createForUser($user);
         $weeklyKpi->setName('Weekly KPI');
-        $weeklyKpi->setUser($user);
         $weeklyKpi->setInterval(KpiInterval::WEEKLY);
         $weeklyPeriod = $weeklyKpi->getCurrentPeriod();
         $this->assertMatchesRegularExpression('/^\d{4}-W\d{2}$/', (string) $weeklyPeriod);
 
         // Teste, dass monthly monatliche Formate erzeugt (Format: YYYY-MM)
-        $monthlyKpi = new KPI();
+        $monthlyKpi = $kpiFactory->createForUser($user);
         $monthlyKpi->setName('Monthly KPI');
-        $monthlyKpi->setUser($user);
         $monthlyKpi->setInterval(KpiInterval::MONTHLY);
         $monthlyPeriod = $monthlyKpi->getCurrentPeriod();
         $this->assertMatchesRegularExpression('/^\d{4}-\d{1,2}$/', (string) $monthlyPeriod);
 
         // Teste, dass quarterly quartalsweise Formate erzeugt (Format: YYYY-QX)
-        $quarterlyKpi = new KPI();
+        $quarterlyKpi = $kpiFactory->createForUser($user);
         $quarterlyKpi->setName('Quarterly KPI');
-        $quarterlyKpi->setUser($user);
         $quarterlyKpi->setInterval(KpiInterval::QUARTERLY);
         $quarterlyPeriod = $quarterlyKpi->getCurrentPeriod();
         $this->assertStringContainsString('Q', (string) $quarterlyPeriod);
@@ -219,10 +214,10 @@ class KpiIntervalIntegrationTest extends KernelTestCase
         $user->setPassword('password');
         $user->setFirstName('Test');
         $user->setLastName('User');
+        $kpiFactory = new KPIFactory();
 
-        $kpi = new KPI();
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Test KPI');
-        $kpi->setUser($user);
 
         // Test mit verschiedenen Intervallen
         foreach (KpiInterval::cases() as $interval) {

--- a/tests/Integration/ValueObject/PeriodIntegrationTest.php
+++ b/tests/Integration/ValueObject/PeriodIntegrationTest.php
@@ -6,9 +6,9 @@ use App\Domain\ValueObject\DecimalValue;
 use App\Domain\ValueObject\EmailAddress;
 use App\Domain\ValueObject\KpiInterval;
 use App\Domain\ValueObject\Period;
-use App\Entity\KPI;
-use App\Entity\KPIValue;
 use App\Entity\User;
+use App\Factory\KPIFactory;
+use App\Factory\KPIValueFactory;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -26,17 +26,17 @@ class PeriodIntegrationTest extends TestCase
         $user->setFirstName('Period');
         $user->setLastName('Test');
 
-        $kpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpiValueFactory = new KPIValueFactory();
+
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Period Integration KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::MONTHLY);
 
         // Test Period integration with KPIValue
         $period = new Period('2024-09');
-        $kpiValue = new KPIValue();
-        $kpiValue->setKpi($kpi);
+        $kpiValue = $kpiValueFactory->create($kpi, $period);
         $kpiValue->setValue(new DecimalValue('1500,50'));
-        $kpiValue->setPeriod($period);
 
         // Test Period methods
         $this->assertSame('2024-09', $kpiValue->getPeriod()->value());
@@ -53,41 +53,35 @@ class PeriodIntegrationTest extends TestCase
         $user->setLastName('Test');
 
         // Test monthly KPI with monthly period
-        $monthlyKpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpiValueFactory = new KPIValueFactory();
+
+        $monthlyKpi = $kpiFactory->createForUser($user);
         $monthlyKpi->setName('Monthly KPI');
-        $monthlyKpi->setUser($user);
         $monthlyKpi->setInterval(KpiInterval::MONTHLY);
 
-        $monthlyValue = new KPIValue();
-        $monthlyValue->setKpi($monthlyKpi);
+        $monthlyValue = $kpiValueFactory->create($monthlyKpi, new Period('2024-06'));
         $monthlyValue->setValue(new DecimalValue('1000'));
-        $monthlyValue->setPeriod(new Period('2024-06'));
 
         $this->assertSame('Juni 2024', $monthlyValue->getFormattedPeriod());
 
         // Test weekly KPI with weekly period
-        $weeklyKpi = new KPI();
+        $weeklyKpi = $kpiFactory->createForUser($user);
         $weeklyKpi->setName('Weekly KPI');
-        $weeklyKpi->setUser($user);
         $weeklyKpi->setInterval(KpiInterval::WEEKLY);
 
-        $weeklyValue = new KPIValue();
-        $weeklyValue->setKpi($weeklyKpi);
+        $weeklyValue = $kpiValueFactory->create($weeklyKpi, new Period('2024-W25'));
         $weeklyValue->setValue(new DecimalValue('250'));
-        $weeklyValue->setPeriod(new Period('2024-W25'));
 
         $this->assertSame('KW 25/2024', $weeklyValue->getFormattedPeriod());
 
         // Test quarterly KPI with quarterly period
-        $quarterlyKpi = new KPI();
+        $quarterlyKpi = $kpiFactory->createForUser($user);
         $quarterlyKpi->setName('Quarterly KPI');
-        $quarterlyKpi->setUser($user);
         $quarterlyKpi->setInterval(KpiInterval::QUARTERLY);
 
-        $quarterlyValue = new KPIValue();
-        $quarterlyValue->setKpi($quarterlyKpi);
+        $quarterlyValue = $kpiValueFactory->create($quarterlyKpi, new Period('2024-Q2'));
         $quarterlyValue->setValue(new DecimalValue('5000'));
-        $quarterlyValue->setPeriod(new Period('2024-Q2'));
 
         $this->assertSame('Q2 2024', $quarterlyValue->getFormattedPeriod());
     }
@@ -101,9 +95,10 @@ class PeriodIntegrationTest extends TestCase
         $user->setLastName('Test');
 
         // Test current period generation for different intervals
-        $monthlyKpi = new KPI();
+        $kpiFactory = new KPIFactory();
+
+        $monthlyKpi = $kpiFactory->createForUser($user);
         $monthlyKpi->setName('Monthly KPI');
-        $monthlyKpi->setUser($user);
         $monthlyKpi->setInterval(KpiInterval::MONTHLY);
 
         $currentPeriod = $monthlyKpi->getCurrentPeriod();
@@ -111,9 +106,8 @@ class PeriodIntegrationTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d{4}-\d{1,2}$/', $currentPeriod->value());
 
         // Test weekly interval
-        $weeklyKpi = new KPI();
+        $weeklyKpi = $kpiFactory->createForUser($user);
         $weeklyKpi->setName('Weekly KPI');
-        $weeklyKpi->setUser($user);
         $weeklyKpi->setInterval(KpiInterval::WEEKLY);
 
         $currentWeeklyPeriod = $weeklyKpi->getCurrentPeriod();
@@ -121,9 +115,8 @@ class PeriodIntegrationTest extends TestCase
         $this->assertMatchesRegularExpression('/^\d{4}-W\d{1,2}$/', $currentWeeklyPeriod->value());
 
         // Test quarterly interval
-        $quarterlyKpi = new KPI();
+        $quarterlyKpi = $kpiFactory->createForUser($user);
         $quarterlyKpi->setName('Quarterly KPI');
-        $quarterlyKpi->setUser($user);
         $quarterlyKpi->setInterval(KpiInterval::QUARTERLY);
 
         $currentQuarterlyPeriod = $quarterlyKpi->getCurrentPeriod();
@@ -193,13 +186,14 @@ class PeriodIntegrationTest extends TestCase
         $user->setFirstName('Validation');
         $user->setLastName('Test');
 
-        $kpi = new KPI();
+        $kpiFactory = new KPIFactory();
+        $kpiValueFactory = new KPIValueFactory();
+
+        $kpi = $kpiFactory->createForUser($user);
         $kpi->setName('Validation KPI');
-        $kpi->setUser($user);
         $kpi->setInterval(KpiInterval::MONTHLY);
 
-        $kpiValue = new KPIValue();
-        $kpiValue->setKpi($kpi);
+        $kpiValue = $kpiValueFactory->create($kpi);
         $kpiValue->setValue(new DecimalValue('1000'));
 
         // Test that invalid period construction throws exception


### PR DESCRIPTION
## Summary
- add KPIFactory and KPIValueFactory for consistent initialization
- inject factories into KPIController and simplify KPI and value creation
- update tests to construct KPIs and values via factories

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b6f2bcad38833187a4d435fba1b5e3