### PR TITLE
Use DashboardKpiEntry DTO for dashboard data

### DIFF
--- a/src/DTO/DashboardKpiEntry.php
+++ b/src/DTO/DashboardKpiEntry.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\DTO;
+
+use App\Entity\KPI;
+use DateTimeInterface;
+
+class DashboardKpiEntry
+{
+    public function __construct(
+        public KPI $kpi,
+        public string $status,
+        public mixed $latestValue,
+        public bool $isDueSoon,
+        public bool $isOverdue,
+        public ?DateTimeInterface $nextDueDate,
+    ) {
+    }
+}

--- a/src/DTO/DashboardKpiEntry.php
+++ b/src/DTO/DashboardKpiEntry.php
@@ -5,8 +5,22 @@ namespace App\DTO;
 use App\Entity\KPI;
 use DateTimeInterface;
 
+
+/**
+ * DTO für die Anzeige eines KPI-Eintrags im Dashboard.
+ *
+ * Enthält Status, letzte Werte und Fälligkeitsinformationen für ein KPI.
+ */
 class DashboardKpiEntry
 {
+    /**
+     * @param KPI $kpi Das zugehörige KPI-Objekt
+     * @param string $status Status des KPI (z.B. "green", "yellow", "red")
+     * @param mixed $latestValue Der zuletzt gemeldete Wert
+     * @param bool $isDueSoon Gibt an, ob das KPI demnächst fällig ist
+     * @param bool $isOverdue Gibt an, ob das KPI überfällig ist
+     * @param DateTimeInterface|null $nextDueDate Das nächste Fälligkeitsdatum, falls vorhanden
+     */
     public function __construct(
         public KPI $kpi,
         public string $status,

--- a/src/Factory/DashboardKpiEntryFactory.php
+++ b/src/Factory/DashboardKpiEntryFactory.php
@@ -7,14 +7,32 @@ use App\Entity\KPI;
 use App\Repository\KPIValueRepository;
 use App\Service\KPIStatusService;
 
+
+/**
+ * Factory zur Erstellung von DashboardKpiEntry-DTOs für die Dashboard-Anzeige.
+ *
+ * Nutzt KPIStatusService und KPIValueRepository, um alle relevanten KPI-Daten für das Dashboard zusammenzustellen.
+ */
 class DashboardKpiEntryFactory
 {
+    /**
+     * Konstruktor injiziert Status-Service und Value-Repository.
+     *
+     * @param KPIStatusService $kpiStatusService Service zur Ermittlung des KPI-Status
+     * @param KPIValueRepository $kpiValueRepository Repository für KPI-Werte
+     */
     public function __construct(
         private KPIStatusService $kpiStatusService,
         private KPIValueRepository $kpiValueRepository,
     ) {
     }
 
+    /**
+     * Erstellt ein DashboardKpiEntry-DTO für ein gegebenes KPI.
+     *
+     * @param KPI $kpi Das zu verarbeitende KPI-Objekt
+     * @return DashboardKpiEntry DTO mit Status, Wert und Fälligkeitsdaten
+     */
     public function create(KPI $kpi): DashboardKpiEntry
     {
         return new DashboardKpiEntry(

--- a/src/Factory/DashboardKpiEntryFactory.php
+++ b/src/Factory/DashboardKpiEntryFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Factory;
+
+use App\DTO\DashboardKpiEntry;
+use App\Entity\KPI;
+use App\Repository\KPIValueRepository;
+use App\Service\KPIStatusService;
+
+class DashboardKpiEntryFactory
+{
+    public function __construct(
+        private KPIStatusService $kpiStatusService,
+        private KPIValueRepository $kpiValueRepository,
+    ) {
+    }
+
+    public function create(KPI $kpi): DashboardKpiEntry
+    {
+        return new DashboardKpiEntry(
+            kpi: $kpi,
+            status: $this->kpiStatusService->getKpiStatus($kpi),
+            latestValue: $this->kpiValueRepository->findLatestValueForKpi($kpi),
+            isDueSoon: $this->kpiStatusService->isDueSoon($kpi),
+            isOverdue: $this->kpiStatusService->isOverdue($kpi),
+            nextDueDate: $kpi->getNextDueDate(),
+        );
+    }
+}

--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -126,20 +126,20 @@
                                             {% endif %}
                                         </td>
                                         <td>
-                                            {% if item.latest_value %}
-                                                <span class="fw-bold">{{ item.latest_value.value }}</span>
+                                            {% if item.latestValue %}
+                                                <span class="fw-bold">{{ item.latestValue.value }}</span>
                                                 {% if item.kpi.unit %}{{ item.kpi.unit }}{% endif %}
-                                                <br><small class="text-muted">{{ item.latest_value.period }}</small>
+                                                <br><small class="text-muted">{{ item.latestValue.period }}</small>
                                             {% else %}
                                                 <span class="text-muted">Noch keine Werte</span>
                                             {% endif %}
                                         </td>
                                         <td>
-                                            {% if item.next_due_date %}
-                                                {{ item.next_due_date|date('d.m.Y') }}
-                                                {% if item.is_overdue %}
+                                            {% if item.nextDueDate %}
+                                                {{ item.nextDueDate|date('d.m.Y') }}
+                                                {% if item.isOverdue %}
                                                     <br><small class="text-danger">Überfällig</small>
-                                                {% elseif item.is_due_soon %}
+                                                {% elseif item.isDueSoon %}
                                                     <br><small class="text-warning">Bald fällig</small>
                                                 {% endif %}
                                             {% else %}

--- a/tests/Service/DashboardServiceTest.php
+++ b/tests/Service/DashboardServiceTest.php
@@ -8,6 +8,8 @@ use App\Repository\KPIRepository;
 use App\Repository\KPIValueRepository;
 use App\Service\DashboardService;
 use App\Service\KPIStatusService;
+use App\DTO\DashboardKpiEntry;
+use App\Factory\DashboardKpiEntryFactory;
 use PHPUnit\Framework\TestCase;
 
 class DashboardServiceTest extends TestCase
@@ -17,10 +19,11 @@ class DashboardServiceTest extends TestCase
         $kpiRepo = $this->createMock(KPIRepository::class);
         $kpiValueRepo = $this->createMock(KPIValueRepository::class);
         $statusService = $this->createMock(KPIStatusService::class);
+        $factory = $this->createMock(DashboardKpiEntryFactory::class);
         $user = $this->createMock(User::class);
 
         $kpiRepo->method('findByUser')->willReturn([]);
-        $service = new DashboardService($kpiRepo, $kpiValueRepo, $statusService);
+        $service = new DashboardService($kpiRepo, $kpiValueRepo, $statusService, $factory);
         $result = $service->getKpiDataForUser($user);
         $this->assertIsArray($result);
     }
@@ -30,20 +33,20 @@ class DashboardServiceTest extends TestCase
         $kpiRepo = $this->createMock(KPIRepository::class);
         $kpiValueRepo = $this->createMock(KPIValueRepository::class);
         $statusService = $this->createMock(KPIStatusService::class);
+        $factory = $this->createMock(DashboardKpiEntryFactory::class);
         $user = $this->createMock(User::class);
 
         $kpi1 = $this->createMock(KPI::class);
-        $kpi1->method('getName')->willReturn('Test KPI 1');
-        $kpi1->method('getStatus')->willReturn('green');
+        $kpi2 = $this->createMock(KPI::class);
 
         $kpiData = [
-            ['name' => 'Test KPI 1', 'status' => 'green', 'due_date' => new \DateTime()],
-            ['name' => 'Test KPI 2', 'status' => 'red', 'due_date' => new \DateTime('-1 day')],
+            new DashboardKpiEntry($kpi1, 'green', null, false, false, new \DateTime()),
+            new DashboardKpiEntry($kpi2, 'red', null, false, true, new \DateTime('-1 day')),
         ];
 
         $kpiValueRepo->method('findRecentByUser')->willReturn([]);
 
-        $service = new DashboardService($kpiRepo, $kpiValueRepo, $statusService);
+        $service = new DashboardService($kpiRepo, $kpiValueRepo, $statusService, $factory);
         $stats = $service->getDashboardStats($user, $kpiData);
 
         $this->assertIsArray($stats);


### PR DESCRIPTION
## Summary
- add DashboardKpiEntry data transfer object with typed properties
- encapsulate KPI entry creation in DashboardKpiEntryFactory
- return DTOs from DashboardService and update templates/tests

## Testing
- `composer install --no-interaction --no-progress`
- `./vendor/bin/phpunit`
- `./vendor/bin/php-cs-fixer fix --dry-run --allow-risky=yes`


------
https://chatgpt.com/codex/tasks/task_e_68b6f2c2dd8c83319e1a65a6243aca76